### PR TITLE
Blueprint updates for CSS and Outpost config

### DIFF
--- a/authentik/blueprints/tak-branding-change.yaml
+++ b/authentik/blueprints/tak-branding-change.yaml
@@ -12,7 +12,15 @@ entries:
     required: false 
 - attrs:
     branding_custom_css: ".pf-c-background-image {\n    --ak-flow-background: radial-gradient(at\
-      \ left top, #4f5255, #3c3f42) !important;\n}"
+      left top, #4f5255, #3c3f42) !important;\n}\n\
+      .pf-c-login__main-footer-links-item img, .pf-c-login__main-footer-links-item .fas {\n\
+      \    filter: invert(0);\n\
+      \n\
+      :host([theme=\"dark\"]) .pf-c-data-list__cell img {\n\
+      \    filter: invert(0);\n\
+      } \n\
+      .pf-c-form-control[readonly] {  \n\
+      \    color: var(--pf-global--disabled-color--100) !important; \n}"
   identifiers:
     domain: authentik-default
   model: authentik_brands.brand

--- a/authentik/blueprints/tak-ldap-setup.yaml
+++ b/authentik/blueprints/tak-ldap-setup.yaml
@@ -5,9 +5,10 @@ metadata:
     blueprints.goauthentik.io/description: |
       This blueprint configures the default LDAP service account.
 context:
-  username: !Env [AUTHENTIK_BOOTSTRAP_LDAPSERVICE_USERNAME, "ldapservice"]
+  username: !Env [AUTHENTIK_BOOTSTRAP_LDAPSERVICE_USERNAME, 'ldapservice']
   password: !Env [AUTHENTIK_BOOTSTRAP_LDAPSERVICE_PASSWORD, null]
-  basedn: !Env [AUTHENTIK_BOOTSTRAP_LDAP_BASEDN, "DC=example,DC=com"]
+  basedn: !Env [AUTHENTIK_BOOTSTRAP_LDAP_BASEDN, 'DC=example,DC=com']
+  authentik_host: !Env [AUTHENTIK_BOOTSTRAP_LDAP_AUTHENTIK_HOST, 'http://localhost:9000/']
 entries:
   - model: authentik_blueprints.metaapplyblueprint
     attrs:
@@ -125,7 +126,7 @@ entries:
       name: LDAP
     attrs:
       config:
-        authentik_host: 'http://localhost:9000/'
+        authentik_host: !Context authentik_host
       providers:
       - !KeyOf provider
       type: ldap


### PR DESCRIPTION
Updated Authenthik blueprints: 
* **CSS:** Fix CSS for social login logos on dark background by removing the logo color invert. 
* ** LDAP Outpost:** Allow configuration on Authentik_Host value via .env values.