### PR TITLE
Update Authentik to release 2025.6

### DIFF
--- a/authentik/temp_fixes/authentik/stages/email/tasks.py
+++ b/authentik/temp_fixes/authentik/stages/email/tasks.py
@@ -1,0 +1,146 @@
+"""email stage tasks"""
+
+from email.utils import make_msgid
+from smtplib import SMTPException
+from typing import Any
+
+from celery import group
+from django.core.mail import EmailMultiAlternatives
+from django.core.mail.utils import DNS_NAME
+from django.utils.text import slugify
+from structlog.stdlib import get_logger
+
+from authentik.events.models import Event, EventAction, TaskStatus
+from authentik.events.system_tasks import SystemTask
+from authentik.lib.utils.reflection import class_to_path, path_to_class
+from authentik.root.celery import CELERY_APP
+from authentik.stages.authenticator_email.models import AuthenticatorEmailStage
+from authentik.stages.email.models import EmailStage
+from authentik.stages.email.utils import logo_data
+
+LOGGER = get_logger()
+
+
+def send_mails(
+    stage: EmailStage | AuthenticatorEmailStage, *messages: list[EmailMultiAlternatives]
+):
+    """Wrapper to convert EmailMessage to dict and send it from worker
+
+    Args:
+        stage: Either an EmailStage or AuthenticatorEmailStage instance
+        messages: List of email messages to send
+    Returns:
+        Celery group promise for the email sending tasks
+    """
+    tasks = []
+    # Use the class path instead of the class itself for serialization
+    stage_class_path = class_to_path(stage.__class__)
+    for message in messages:
+        tasks.append(send_mail.s(message.__dict__, stage_class_path, str(stage.pk)))
+    lazy_group = group(*tasks)
+    promise = lazy_group()
+    return promise
+
+
+def get_email_body(email: EmailMultiAlternatives) -> str:
+    """Get the email's body. Will return HTML alt if set, otherwise plain text body"""
+    for alt_content, alt_type in email.alternatives:
+        if alt_type == "text/html":
+            return alt_content
+    return email.body
+
+
+@CELERY_APP.task(
+    bind=True,
+    autoretry_for=(
+        SMTPException,
+        ConnectionError,
+        OSError,
+    ),
+    retry_backoff=True,
+    base=SystemTask,
+)
+def send_mail(
+    self: SystemTask,
+    message: dict[Any, Any],
+    stage_class_path: str | None = None,
+    email_stage_pk: str | None = None,
+):
+    """Send Email for Email Stage. Retries are scheduled automatically."""
+    self.save_on_success = False
+    message_id = make_msgid(domain=DNS_NAME)
+    self.set_uid(slugify(message_id.replace(".", "_").replace("@", "_")))
+    try:
+        if not stage_class_path or not email_stage_pk:
+            stage = EmailStage(use_global_settings=True)
+        else:
+            stage_class = path_to_class(stage_class_path)
+            stages = stage_class.objects.filter(pk=email_stage_pk)
+            if not stages.exists():
+                self.set_status(
+                    TaskStatus.WARNING,
+                    "Email stage does not exist anymore. Discarding message.",
+                )
+                return
+            stage: EmailStage | AuthenticatorEmailStage = stages.first()
+        try:
+            backend = stage.backend
+        except ValueError as exc:
+            LOGGER.warning("failed to get email backend", exc=exc)
+            self.set_error(exc)
+            return
+        backend.open()
+        # Since django's EmailMessage objects are not JSON serialisable,
+        # we need to rebuild them from a dict
+        message_object = EmailMultiAlternatives()
+        for key, value in message.items():
+            setattr(message_object, key, value)
+        if not stage.use_global_settings:
+            message_object.from_email = stage.from_address
+        # Because we use the Message-ID as UID for the task, manually assign it
+        message_object.extra_headers["Message-ID"] = message_id
+
+        # Add the logo (we can't add it in the previous message since MIMEImage
+        # can't be converted to json)
+        body=get_email_body(message_object),
+        if "cid:logo" in body:
+            message_object.attach(logo_data())
+
+        if (
+            message_object.to
+            and isinstance(message_object.to[0], str)
+            and "=?utf-8?" in message_object.to[0]
+        ):
+            message_object.to = [message_object.to[0].split("<")[-1].replace(">", "")]
+
+        LOGGER.debug("Sending mail", to=message_object.to)
+        backend.send_messages([message_object])
+        Event.new(
+            EventAction.EMAIL_SENT,
+            message=f"Email to {', '.join(message_object.to)} sent",
+            subject=message_object.subject,
+            body=get_email_body(message_object),
+            from_email=message_object.from_email,
+            to_email=message_object.to,
+        ).save()
+        self.set_status(
+            TaskStatus.SUCCESSFUL,
+            "Successfully sent Mail.",
+        )
+    except (SMTPException, ConnectionError, OSError) as exc:
+        LOGGER.debug("Error sending email, retrying...", exc=exc)
+        self.set_error(exc)
+        raise exc
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/authentik/temp_fixes/authentik/stages/email/templates/email/base.html
+++ b/authentik/temp_fixes/authentik/stages/email/templates/email/base.html
@@ -1,0 +1,132 @@
+{% load authentik_stages_email %}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtm=l">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width">
+
+    <style type="text/css">
+      body {
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        color: #212124;
+      }
+
+      h2 {
+        display: inline-block;
+        font-family: Arial, sans-serif;
+        font-size: 28px;
+        line-height: 125%;
+        font-weight: 700;
+        padding-top: 10px;
+        padding-bottom: 10px;
+        margin: 0;
+      }
+
+      .flexibleImage {
+        height: auto;
+      }
+
+      img.logo {
+        max-width: 100%;
+        max-height: 70px;
+      }
+
+      .properties-table {
+        width: 100%;
+        text-align: left;
+        font-size: 14px;
+        font-weight: 400;
+        font-family: Arial, sans-serif;
+        border-collapse: collapse;
+      }
+
+      .properties-table tr:first-child {
+        border-top: 1px solid rgba(196, 196, 196, 0.2);
+      }
+
+      .properties-table tr:first-child>td {
+        padding-top: 24px;
+      }
+
+      .properties-table tr:last-child {
+        border-bottom: 1px solid rgba(196, 196, 196, 0.2);
+      }
+
+      .properties-table tr:last-child>td {
+        padding-bottom: 24px;
+      }
+
+      .properties-table td {
+        line-height: 24px;
+        vertical-align: top;
+        padding: 4px 15px;
+      }
+
+      .td-right {
+        text-align: right;
+        white-space: nowrap;
+      }
+      .btn-primary {
+        text-decoration: none;
+        color: #FFF;
+        background-color: #348eda;
+        border: solid #348eda;
+        width: 100%;
+        line-height: 2em;
+        font-weight: bold;
+        text-align: center;
+        cursor: pointer;
+        display: inline-block;
+        text-transform: capitalize;
+      }
+      .btn-primary a {
+        color: #fff;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="wrapper">
+      <center>
+        <div style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; table-layout: fixed; width: 100%; max-width: 448px; padding: 60px 20px; font-size: 14px;">
+          <table border="0" align="center" width="100%">
+            <tr>
+              <td style="padding: 20px;border: 1px solid #c1c1c1;">
+                <table width="100%" style="background-color: #FFFFFF; border-spacing: 0; margin-top: 15px;">
+                  <tr height="80">
+                    <td align="center" style="padding: 20px 0;">
+                      <img src="{% block logo_url %}https://tak.nz/images/logo/tak-nz-brand-wide.png{% endblock %}" border="0=" alt="TAK.NZ logo" class="flexibleImage logo
+">
+                    </td>
+                  </tr>
+                  {% block content %}
+                  {% endblock %}
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table border="0" style="margin-top: 10px;" width="100%">
+                  <tr>
+                    <td style="background: #FAFBFB;">
+                      <table style="width: 100%;">
+                        {% block sub_content %}
+                        {% endblock %}
+                      </table>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <td align="center">
+                <a href="https://tak.nz/">Team Awareness • Te mōhio o te rōpū</a>.
+              </td>
+            </tr>
+          </table>
+        </div>
+      </center>
+    </div>
+  </body>
+</html>

--- a/authentik/temp_fixes/authentik/stages/email/utils.py
+++ b/authentik/temp_fixes/authentik/stages/email/utils.py
@@ -1,0 +1,57 @@
+"""email utils"""
+
+from email.mime.image import MIMEImage
+from functools import lru_cache
+from pathlib import Path
+
+from django.core.mail import EmailMultiAlternatives
+from django.core.mail.message import sanitize_address
+from django.template.exceptions import TemplateDoesNotExist
+from django.template.loader import render_to_string
+from django.utils import translation
+
+
+@lru_cache
+def logo_data() -> MIMEImage:
+    """Get logo as MIME Image for emails"""
+    path = Path("web/icons/icon_left_brand.png")
+    if not path.exists():
+        path = Path("web/dist/assets/icons/icon_left_brand.png")
+    with open(path, "rb") as _logo_file:
+        logo = MIMEImage(_logo_file.read())
+    logo.add_header('Content-ID', '<logo.png>')
+    logo.add_header('Content-Disposition', 'inline', filename='logo.png')
+    return logo
+
+
+class TemplateEmailMessage(EmailMultiAlternatives):
+    """Wrapper around EmailMultiAlternatives with integrated template rendering"""
+
+    def __init__(
+        self, to: list[tuple[str]], template_name=None, template_context=None, language="", **kwargs
+    ):
+        sanitized_to = []
+        # Ensure that all recipients are valid
+        for recipient_name, recipient_email in to:
+            # Remove any newline characters from name and email before sanitizing
+            clean_name = (
+                recipient_name.replace("\n", " ").replace("\r", " ") if recipient_name else ""
+            )
+            clean_email = (
+                recipient_email.replace("\n", "").replace("\r", "") if recipient_email else ""
+            )
+            sanitized_to.append(sanitize_address((clean_name, clean_email), "utf-8"))
+        super().__init__(to=sanitized_to, **kwargs)
+        if not template_name:
+            return
+        with translation.override(language):
+            html_content = render_to_string(template_name, template_context)
+            try:
+                text_content = render_to_string(
+                    template_name.replace("html", "txt"), template_context
+                )
+                self.body = text_content
+            except TemplateDoesNotExist:
+                pass
+        self.mixed_subtype = "related"
+        self.attach_alternative(html_content, "text/html")

--- a/cloudformation/lib/authentik.js
+++ b/cloudformation/lib/authentik.js
@@ -247,8 +247,8 @@ export default {
             Properties: {
                 Family: cf.join('-', [cf.stackName, 'server']),
                 // Task Size options: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
-                Cpu: 512,
-                Memory: 1024,
+                Cpu: 1024,
+                Memory: 2048,
                 NetworkMode: 'awsvpc',
                 RequiresCompatibilities: ['FARGATE'],
                 Tags: [{

--- a/cloudformation/lib/authentik.js
+++ b/cloudformation/lib/authentik.js
@@ -305,7 +305,7 @@ export default {
                         // { Name: 'AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__PORT', Value: '5432' },
                         { Name: 'AUTHENTIK_REDIS__HOST',                        Value: cf.getAtt('Redis', 'PrimaryEndPoint.Address') },
                         { Name: 'AUTHENTIK_REDIS__TLS',                         Value: 'True' },
-                        { Name: 'AUTHENTIK_REDIS__TLS_REQS',                    Value: 'required' },
+                        { Name: 'AUTHENTIK_REDIS__TLS_REQS',                    Value: 'required' }
                     ],
                     Secrets: [
                         { Name: 'AUTHENTIK_POSTGRESQL__PASSWORD',                   ValueFrom: cf.join([cf.ref('DBMasterSecret'), ':password::']) },

--- a/cloudformation/lib/authentik.js
+++ b/cloudformation/lib/authentik.js
@@ -304,7 +304,8 @@ export default {
                         // { Name: 'AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__NAME', Value: 'authentik' },
                         // { Name: 'AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__PORT', Value: '5432' },
                         { Name: 'AUTHENTIK_REDIS__HOST',                        Value: cf.getAtt('Redis', 'PrimaryEndPoint.Address') },
-                        { Name: 'AUTHENTIK_REDIS__TLS',                         Value: 'True' }
+                        { Name: 'AUTHENTIK_REDIS__TLS',                         Value: 'True' },
+                        { Name: 'AUTHENTIK_REDIS__TLS_REQS',                    Value: 'required' },
                     ],
                     Secrets: [
                         { Name: 'AUTHENTIK_POSTGRESQL__PASSWORD',                   ValueFrom: cf.join([cf.ref('DBMasterSecret'), ':password::']) },
@@ -545,6 +546,7 @@ export default {
                         // { Name: 'AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__PORT', Value: '5432' },
                         { Name: 'AUTHENTIK_REDIS__HOST',                        Value: cf.getAtt('Redis', 'PrimaryEndPoint.Address') },
                         { Name: 'AUTHENTIK_REDIS__TLS',                         Value: 'True' },
+                        { Name: 'AUTHENTIK_REDIS__TLS_REQS',                    Value: 'required' },
                         { Name: 'AUTHENTIK_BOOTSTRAP_EMAIL',                    Value: cf.ref('AuthentikAdminUserEmail') },
                         { Name: 'AUTHENTIK_BOOTSTRAP_LDAPSERVICE_USERNAME',     Value: cf.sub('{{resolve:secretsmanager:${AWS::StackName}/ldapservice:SecretString:username:AWSCURRENT}}') },
                         { Name: 'AUTHENTIK_BOOTSTRAP_LDAP_BASEDN',              Value: cf.ref('AuthentikLDAPBaseDN') }

--- a/docker/amd64/Dockerfile.authentik-ldap
+++ b/docker/amd64/Dockerfile.authentik-ldap
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/ldap:2025.4.1
+FROM ghcr.io/goauthentik/ldap:2025.6
 LABEL org.opencontainers.image.source=https://github.com/tak-nz/auth-infra-ldap
 LABEL org.opencontainers.image.description="Authentik LDAP outpost for TAK server auth via LDAP"
 LABEL org.opencontainers.image.licenses=MIT

--- a/docker/amd64/Dockerfile.authentik-server
+++ b/docker/amd64/Dockerfile.authentik-server
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/server:2025.4.1
+FROM ghcr.io/goauthentik/server:2025.6
 LABEL org.opencontainers.image.source=https://github.com/tak-nz/auth-infra-server
 LABEL org.opencontainers.image.description="Authentik server for TAK server auth via LDAP"
 LABEL org.opencontainers.image.licenses=MIT
@@ -11,3 +11,4 @@ COPY authentik/branding/icons/tak-logo.svg /web/dist/assets/icons/brand.svg
 COPY authentik/branding/icons/tak-logo.svg /web/dist/assets/icons/icon.svg
 COPY authentik/branding/icons/tak-logo.svg /web/dist/assets/icons/icon_left_brand.svg
 COPY authentik/branding/icons/tak-logo.svg /web/dist/assets/icons/icon_top_brand.svg
+COPY authentik/temp_fixes/authentik/ /authentik/

--- a/docker/amd64/Dockerfile.authentik-server-tak-nz
+++ b/docker/amd64/Dockerfile.authentik-server-tak-nz
@@ -1,4 +1,4 @@
-FROM ghcr.io/goauthentik/server:2025.4.1
+FROM ghcr.io/goauthentik/server:2025.6
 LABEL org.opencontainers.image.source=https://github.com/tak-nz/auth-infra-server
 LABEL org.opencontainers.image.description="Authentik server for TAK server auth via LDAP"
 LABEL org.opencontainers.image.licenses=MIT
@@ -11,3 +11,4 @@ COPY authentik/branding/icons/tak-nz-brand-wide.svg /web/dist/assets/icons/brand
 COPY authentik/branding/icons/tak-nz-logo.svg /web/dist/assets/icons/icon.svg
 COPY authentik/branding/icons/tak-nz-brand-wide.svg /web/dist/assets/icons/icon_left_brand.svg
 COPY authentik/branding/icons/tak-nz-brand-tall.svg /web/dist/assets/icons/icon_top_brand.svg
+COPY authentik/temp_fixes/authentik/ /authentik/


### PR DESCRIPTION
Changes:
 * **Updates Authentik version**: Update to release 2026.6.
 * **Fixes for Valkey with TLS**: Enforces use of TLS with Redis/Valkey.
 * **Temporary Fix for the E-Mail stage**: Overrides certain files to make sure that the Authentik image is not attached to notification mails. Changed has been [proposed upstream](https://github.com/goauthentik/authentik/pull/14835).