### PR TITLE
Security configuration update

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -51,7 +51,8 @@
         "useS3AuthentikConfigFile": false,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.6.2"
+        "authentikVersion": "2025.6.2",
+        "outboundEmailServerPort": 587
       },
       "ecr": {
         "imageRetentionCount": 5,
@@ -97,7 +98,8 @@
         "useS3AuthentikConfigFile": true,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.6.2"
+        "authentikVersion": "2025.6.2",
+        "outboundEmailServerPort": 587
       },
       "ecr": {
         "imageRetentionCount": 20,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -57,7 +57,8 @@ All configurations are stored in [`cdk.json`](../cdk.json) under the `context` s
         "useS3AuthentikConfigFile": false,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.6.2"
+        "authentikVersion": "2025.6.2",
+        "outboundEmailServerPort": 587
       },
       "ecr": {
         "imageRetentionCount": 5,
@@ -103,7 +104,8 @@ All configurations are stored in [`cdk.json`](../cdk.json) under the `context` s
         "useS3AuthentikConfigFile": true,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.6.2"
+        "authentikVersion": "2025.6.2",
+        "outboundEmailServerPort": 587
       },
       "ecr": {
         "imageRetentionCount": 20,
@@ -193,6 +195,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `enablePostgresReadReplicas` | Enable read replicas (currently disabled) | `false` | `false` |
 | `branding` | Docker image branding variant | `tak-nz` | `tak-nz` |
 | `authentikVersion` | Authentik version | `2025.6.2` | `2025.6.2` |
+| `outboundEmailServerPort` | Email server port for outbound connections | `587` | `587` |
 
 ### **ECR Configuration**
 | Parameter | Description | dev-test | prod |

--- a/lib/auth-infra-stack.ts
+++ b/lib/auth-infra-stack.ts
@@ -185,7 +185,8 @@ export class AuthInfraStack extends cdk.Stack {
     const securityGroups = new SecurityGroups(this, 'SecurityGroups', {
       vpc,
       stackNameComponent,
-      albSecurityGroup: authentikELB.loadBalancer.connections.securityGroups[0]
+      albSecurityGroup: authentikELB.loadBalancer.connections.securityGroups[0],
+      outboundEmailServerPort: envConfig.authentik.outboundEmailServerPort
     });
 
     // =================

--- a/lib/constructs/security-groups.ts
+++ b/lib/constructs/security-groups.ts
@@ -89,6 +89,16 @@ export class SecurityGroups extends Construct {
 
     // Authentik Server outbound rules
     this.addEcsOutboundRules(this.authentikServer);
+    this.authentikServer.addEgressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(emailServerPort),
+      'Allow outbound email server access'
+    );
+    this.authentikServer.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(emailServerPort),
+      'Allow outbound email server access IPv6'
+    );
 
     // Create Authentik Worker security group
     this.authentikWorker = new ec2.SecurityGroup(this, 'AuthentikWorker', {

--- a/lib/constructs/security-groups.ts
+++ b/lib/constructs/security-groups.ts
@@ -27,6 +27,11 @@ export interface SecurityGroupsProps {
    * ALB security group to reference
    */
   albSecurityGroup: ec2.ISecurityGroup;
+
+  /**
+   * Outbound email server port (default: 587)
+   */
+  outboundEmailServerPort?: number;
 }
 
 /**
@@ -66,6 +71,8 @@ export class SecurityGroups extends Construct {
   constructor(scope: Construct, id: string, props: SecurityGroupsProps) {
     super(scope, id);
 
+    const emailServerPort = props.outboundEmailServerPort ?? 587;
+
     // Create Authentik Server security group
     this.authentikServer = new ec2.SecurityGroup(this, 'AuthentikServer', {
       vpc: props.vpc,
@@ -90,8 +97,18 @@ export class SecurityGroups extends Construct {
       allowAllOutbound: false
     });
 
-    // Authentik Worker outbound rules (same as server)
+    // Authentik Worker outbound rules (includes email server access)
     this.addEcsOutboundRules(this.authentikWorker);
+    this.authentikWorker.addEgressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(emailServerPort),
+      'Allow outbound email server access'
+    );
+    this.authentikWorker.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(emailServerPort),
+      'Allow outbound email server access IPv6'
+    );
 
     // Create LDAP NLB security group
     this.ldapNlb = new ec2.SecurityGroup(this, 'LDAPNLB', {
@@ -127,6 +144,11 @@ export class SecurityGroups extends Construct {
       ec2.Peer.anyIpv4(),
       ec2.Port.tcp(443),
       'Allow HTTPS access to Authentik server'
+    );
+    this.ldap.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(443),
+      'Allow HTTPS access to Authentik server IPv6'
     );
     this.addDnsRules(this.ldap);
 
@@ -182,9 +204,19 @@ export class SecurityGroups extends Construct {
       'Allow PostgreSQL access'
     );
     securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(DATABASE_CONSTANTS.PORT),
+      'Allow PostgreSQL access IPv6'
+    );
+    securityGroup.addEgressRule(
       ec2.Peer.anyIpv4(),
       ec2.Port.tcp(REDIS_CONSTANTS.PORT),
       'Allow Redis access'
+    );
+    securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(REDIS_CONSTANTS.PORT),
+      'Allow Redis access IPv6'
     );
     securityGroup.addEgressRule(
       ec2.Peer.anyIpv4(),
@@ -192,9 +224,19 @@ export class SecurityGroups extends Construct {
       'Allow EFS access'
     );
     securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(EFS_CONSTANTS.PORT),
+      'Allow EFS access IPv6'
+    );
+    securityGroup.addEgressRule(
       ec2.Peer.anyIpv4(),
       ec2.Port.tcp(443),
       'Allow HTTPS access'
+    );
+    securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(443),
+      'Allow HTTPS access IPv6'
     );
     this.addDnsRules(securityGroup);
   }
@@ -209,9 +251,19 @@ export class SecurityGroups extends Construct {
       'Allow DNS access'
     );
     securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.tcp(53),
+      'Allow DNS access IPv6'
+    );
+    securityGroup.addEgressRule(
       ec2.Peer.anyIpv4(),
       ec2.Port.udp(53),
       'Allow DNS access'
+    );
+    securityGroup.addEgressRule(
+      ec2.Peer.anyIpv6(),
+      ec2.Port.udp(53),
+      'Allow DNS access IPv6'
     );
   }
 

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -42,6 +42,7 @@ export interface ContextEnvironmentConfig {
     enablePostgresReadReplicas?: boolean;
     branding: string;
     authentikVersion: string;
+    outboundEmailServerPort?: number;
   };
   ecr: {
     imageRetentionCount: number;


### PR DESCRIPTION
* **Outbound E-Mails**: Added outbound email security group rules to support SMTP traffic on configurable ports (default 587). Extended Authentik server security group to allow outbound email access for web interface testing. Added outboundEmailServerPort configuration parameter to stack config for flexible SMTP port settings.
* **Outbond IPv6 rules**: Implemented IPv6 support for outbound email traffic alongside existing IPv4 rules  