### PR TITLE
Standardize AWS Resource Naming with TAK Prefix

### DIFF
--- a/lib/constructs/authentik-server.ts
+++ b/lib/constructs/authentik-server.ts
@@ -196,6 +196,7 @@ export class AuthentikServer extends Construct {
 
     // Create task definition
     this.taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDef', {
+      family: 'TAK-Demo-AuthInfra-AuthentikServer',
       cpu: props.contextConfig.ecs.taskCpu,
       memoryLimitMiB: props.contextConfig.ecs.taskMemory,
       executionRole,
@@ -370,6 +371,7 @@ export class AuthentikServer extends Construct {
   public createTargetGroup(vpc: ec2.IVpc, listener: elbv2.ApplicationListener): elbv2.ApplicationTargetGroup {
     // Create target group for the Authentik service
     const targetGroup = new elbv2.ApplicationTargetGroup(this, 'TargetGroup', {
+      targetGroupName: `tak-${props.contextConfig.stackName.toLowerCase()}-authentik`,
       vpc: vpc,
       targetType: elbv2.TargetType.IP,
       port: 9443,

--- a/lib/constructs/authentik-worker.ts
+++ b/lib/constructs/authentik-worker.ts
@@ -182,6 +182,7 @@ export class AuthentikWorker extends Construct {
 
     // Create task definition
     this.taskDefinition = new ecs.FargateTaskDefinition(this, 'WorkerTaskDef', {
+      family: 'TAK-Demo-AuthInfra-AuthentikWorker',
       cpu: props.contextConfig.ecs.taskCpu,
       memoryLimitMiB: props.contextConfig.ecs.taskMemory,
       executionRole,

--- a/lib/constructs/elb.ts
+++ b/lib/constructs/elb.ts
@@ -59,7 +59,7 @@ export class Elb extends Construct {
 
     // Create load balancer with dualstack IP addressing
     this.loadBalancer = new elbv2.ApplicationLoadBalancer(this, 'ALB', {
-      loadBalancerName: `${props.contextConfig.stackName.toLowerCase()}-auth`,
+      loadBalancerName: `tak-${props.contextConfig.stackName.toLowerCase()}-auth`,
       vpc: props.infrastructure.vpc,
       internetFacing: true,
       ipAddressType: elbv2.IpAddressType.DUAL_STACK

--- a/lib/constructs/ldap.ts
+++ b/lib/constructs/ldap.ts
@@ -126,7 +126,7 @@ export class Ldap extends Construct {
 
     // Create network load balancer
     this.loadBalancer = new elbv2.NetworkLoadBalancer(this, 'NLB', {
-      loadBalancerName: `${props.contextConfig.stackName.toLowerCase()}-ldap`,
+      loadBalancerName: `tak-${props.contextConfig.stackName.toLowerCase()}-ldap`,
       vpc: props.infrastructure.vpc,
       internetFacing: false,
       ipAddressType: elbv2.IpAddressType.DUAL_STACK,
@@ -192,6 +192,7 @@ export class Ldap extends Construct {
 
     // Create task definition
     this.taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDef', {
+      family: 'TAK-Demo-AuthInfra-LDAPService',
       cpu: props.contextConfig.ecs.taskCpu,
       memoryLimitMiB: props.contextConfig.ecs.taskMemory,
       executionRole,
@@ -257,6 +258,7 @@ export class Ldap extends Construct {
 
     // Create target groups for LDAP and LDAPS
     const ldapTargetGroup = new elbv2.NetworkTargetGroup(this, 'LdapTargetGroup', {
+      targetGroupName: `tak-${props.contextConfig.stackName.toLowerCase()}-ldap`,
       vpc: props.infrastructure.vpc,
       targetType: elbv2.TargetType.IP,
       port: 3389,
@@ -269,6 +271,7 @@ export class Ldap extends Construct {
     });
 
     const ldapsTargetGroup = new elbv2.NetworkTargetGroup(this, 'LdapsTargetGroup', {
+      targetGroupName: `tak-${props.contextConfig.stackName.toLowerCase()}-ldaps`,
       vpc: props.infrastructure.vpc,
       targetType: elbv2.TargetType.IP,
       port: 6636,


### PR DESCRIPTION
# Standardize AWS Resource Naming with TAK Prefix

## Summary
Updates AWS resource names to follow consistent TAK naming convention across load balancers, target groups, and ECS task definitions.

## Changes
- **Load Balancers:**
  - ALB: `{envName}-auth` → `tak-{envName}-auth`
  - NLB: `{envName}-ldap` → `tak-{envName}-ldap`

- **Target Groups:**
  - Port 9443: `tak-{envName}-authentik`
  - Port 3389: `tak-{envName}-ldap`
  - Port 6636: `tak-{envName}-ldaps`

- **ECS Task Definitions:**
  - `TAK-Demo-AuthInfra-AuthentikServer`
  - `TAK-Demo-AuthInfra-AuthentikWorker`
  - `TAK-Demo-AuthInfra-LDAPService`

## Deployment Impact
⚠️ **Breaking Change**: Requires stack destruction and redeployment due to resource name changes.

```bash
cdk destroy
cdk deploy
