### PR TITLE
Complete GitHub Actions Workflow Fixes

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -72,18 +72,7 @@ jobs:
 
       - name: Deploy Demo with Prod Profile
         # Use dev-test Redis settings to avoid slow Redis changes (>1 hour deployment)
-        run: |
-          npm run cdk deploy -- \
-            --context envType=prod \
-            --context stackName=${{ vars.STACK_NAME }} \
-            --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} \
-            --context nodeType=cache.t3.micro \
-            --context numCacheNodes=1 \
-            --context useS3AuthentikConfigFile=true \
-            --context usePreBuiltImages=true \
-            --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} \
-            --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} \
-            --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context nodeType=cache.t3.micro --context numCacheNodes=1 --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}
@@ -99,13 +88,5 @@ jobs:
         if: always()
 
       - name: Revert Demo to Dev-Test Profile
-        run: |
-          npm run cdk deploy -- \
-            --context envType=dev-test \
-            --context stackName=${{ vars.STACK_NAME }} \
-            --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} \
-            --context usePreBuiltImages=true \
-            --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} \
-            --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} \
-            --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} --require-approval never
         if: always()

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,20 @@ on:
     paths:
       - 'docker/**'
       - 'cdk.json'
+  workflow_call:
+    inputs:
+      force_rebuild:
+        description: 'Force rebuild even if version unchanged'
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      authentik-tag:
+        description: 'Authentik image tag'
+        value: ${{ jobs.build-images.outputs.authentik-tag }}
+      ldap-tag:
+        description: 'LDAP image tag'
+        value: ${{ jobs.build-images.outputs.ldap-tag }}
   workflow_dispatch:
     inputs:
       force_rebuild:


### PR DESCRIPTION
## Complete GitHub Actions Workflow Fixes

### Final Issues Resolved
1. **Reusable Workflow**: Added `workflow_call` trigger to docker-build.yml so it can be called by demo-deploy.yml
2. **Remaining Multi-line Commands**: Converted the last CDK deploy commands to single lines to prevent parsing errors

### Changes
- **docker-build.yml**: Added `workflow_call` trigger with inputs/outputs for reusability
- **demo-deploy.yml**: Converted remaining multi-line CDK deploy commands to single lines

### Result
All GitHub Actions workflows now use consistent single-line CDK command format that prevents argument parsing issues, and the docker-build workflow can be properly called as a dependency.
