### PR TITLE
Debug ECR Repository Retrieval Issue

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,15 +53,29 @@ jobs:
       - name: Get ECR Repository and Build Tags
         id: tags
         run: |
+          # Debug: List all stack outputs
+          echo "Checking BaseInfra stack outputs:"
+          aws cloudformation describe-stacks --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra --query 'Stacks[0].Outputs[*].{Key:OutputKey,Value:OutputValue}' --output table
+          
           # Get ECR repository ARN from BaseInfra exports
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
             --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
             --query 'Stacks[0].Outputs[?OutputKey==`EcrRepoArn`].OutputValue' \
             --output text)
           
+          echo "ECR Repository ARN: $ECR_REPO_ARN"
+          
+          if [[ -z "$ECR_REPO_ARN" ]]; then
+            echo "ERROR: ECR repository ARN not found in BaseInfra stack outputs"
+            exit 1
+          fi
+          
           # Extract repository name from ARN and build URI
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
           ECR_REPO_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
+          
+          echo "ECR Repository Name: $ECR_REPO_NAME"
+          echo "ECR Repository URI: $ECR_REPO_URI"
           
           VERSION=$(jq -r '.context."dev-test".authentik.authentikVersion' cdk.json)
           BRANDING=$(jq -r '.context."dev-test".authentik.branding' cdk.json)


### PR DESCRIPTION
## Debug ECR Repository Retrieval Issue

### Problem
Docker build is failing with "invalid reference format" error because the ECR repository URI is empty, indicating the CloudFormation query isn't finding the ECR repository ARN from BaseInfra.

### Solution
Added comprehensive debugging to identify the root cause:
- List all BaseInfra stack outputs to verify export names
- Add error handling for empty ECR repository ARN
- Enhanced logging to show each step of the ECR URI construction

### Changes
- **docker-build.yml**: Added debugging output and validation for ECR repository retrieval

This will help identify whether the issue is:
1. Incorrect CloudFormation export name
2. Missing BaseInfra stack or ECR output
3. Query syntax problems

Once we see the actual stack outputs, we can fix the correct export name reference.
