### PR TITLE
Fix ECR Repository ARN Query

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -60,7 +60,7 @@ jobs:
           # Get ECR repository ARN from BaseInfra exports
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
             --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
-            --query 'Stacks[0].Outputs[?OutputKey==`EcrRepoArn`].OutputValue' \
+            --query 'Stacks[0].Outputs[?OutputKey==`EcrRepoArnOutput`].OutputValue' \
             --output text)
           
           echo "ECR Repository ARN: $ECR_REPO_ARN"


### PR DESCRIPTION
## Fix ECR Repository ARN Query

### Problem
Docker build was failing because the CloudFormation query was looking for output key `EcrRepoArn` but the actual BaseInfra stack exports it as `EcrRepoArnOutput`.

### Solution
Updated the CloudFormation query to use the correct output key name as shown in the debugging output.

### Changes
- **docker-build.yml**: Changed query from `EcrRepoArn` to `EcrRepoArnOutput`

The debugging output clearly showed all available outputs, making it easy to identify the correct key name. This should resolve the "invalid reference format" Docker tag error.
