### PR TITLE
Fix CDK Commands and Docker Image Tag Consistency

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -64,8 +64,8 @@ jobs:
           BRANDING=$(jq -r '.context."dev-test".authentik.branding' cdk.json)
           REVISION=$(jq -r '.context."dev-test".authentik.buildRevision' cdk.json)
           
-          AUTHENTIK_TAG="authentik:${VERSION}-${BRANDING}-r${REVISION}"
-          LDAP_TAG="ldap:${VERSION}-r${REVISION}"
+          AUTHENTIK_TAG="authentik-${VERSION}-${BRANDING}-r${REVISION}"
+          LDAP_TAG="ldap-${VERSION}-r${REVISION}"
           
           echo "authentik-tag=$AUTHENTIK_TAG" >> $GITHUB_OUTPUT
           echo "ldap-tag=$LDAP_TAG" >> $GITHUB_OUTPUT

--- a/scripts/github/check-breaking-changes.sh
+++ b/scripts/github/check-breaking-changes.sh
@@ -39,7 +39,7 @@ esac
 echo "🔍 Checking for breaking changes in $STACK_TYPE stack..."
 
 # Generate CDK diff
-npm run cdk diff --context envType=$CONTEXT_ENV > stack-diff.txt 2>&1
+npm run cdk diff -- --context envType=$CONTEXT_ENV --context stackName=Demo --context adminUserEmail=admin@tak.nz > stack-diff.txt 2>&1
 
 # Check for breaking patterns
 BREAKING_FOUND=false

--- a/scripts/github/validate-changeset.sh
+++ b/scripts/github/validate-changeset.sh
@@ -13,7 +13,7 @@ if ! aws cloudformation describe-stacks --stack-name "$STACK_NAME" >/dev/null 2>
 fi
 
 # Generate CDK template with same context as deployment
-npm run cdk synth --context envType=prod --context stackName=$STACK_NAME > template.json
+npm run cdk synth -- --context envType=prod --context stackName=Demo --context adminUserEmail=admin@tak.nz > template.json
 
 # Create change set
 aws cloudformation create-change-set \


### PR DESCRIPTION
## Fix CDK Commands and Docker Image Tag Consistency

### Problems Fixed
1. **Script CDK Commands**: validate-changeset.sh and check-breaking-changes.sh had incorrect CDK command syntax missing `--` separator and required context parameters
2. **Image Tag Mismatch**: demo-deploy workflow was generating tags with colons (`authentik:2025.6.3-tak-nz-r1`) while docker-build creates them with dashes (`authentik-2025.6.3-tak-nz-r1`)

### Solutions
- **Scripts**: Added proper `--` separator and all required context parameters to CDK commands
- **Tag Format**: Updated demo-deploy to use dash-separated tags matching docker-build output

### Changes
- `scripts/github/validate-changeset.sh`: Fixed CDK synth command format
- `scripts/github/check-breaking-changes.sh`: Fixed CDK diff command format  
- `.github/workflows/demo-deploy.yml`: Updated image tag format to use dashes

This resolves the "image not found" error by ensuring tag consistency between build and deploy workflows.
