### PR TITLE
🔧 Simplify LDAP Token Retriever + Fix Blueprint Dependencies

### DIFF
--- a/authentik/blueprints/tak-ldap-setup.yaml
+++ b/authentik/blueprints/tak-ldap-setup.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     blueprints.goauthentik.io/description: |
       This blueprint configures the default LDAP service account.
+    blueprints.goauthentik.io/depends-on: "default-flows,default-stages"
 context:
   username: !Env [AUTHENTIK_BOOTSTRAP_LDAPSERVICE_USERNAME, 'ldapservice']
   password: !Env [AUTHENTIK_BOOTSTRAP_LDAPSERVICE_PASSWORD, null]
@@ -14,12 +15,17 @@ entries:
     attrs:
       identifiers:
         name: Default - Invalidation flow
-      required: false 
+      required: true
   - model: authentik_blueprints.metaapplyblueprint
     attrs:
       identifiers:
         name: Default - Password change flow
-      required: false
+      required: true
+  - model: authentik_blueprints.metaapplyblueprint
+    attrs:
+      identifiers:
+        name: Default - Authentication flow
+      required: true
   - model: authentik_core.user
     state: created
     id: ldap-service-account


### PR DESCRIPTION
# 🔧 Simplify LDAP Token Retriever + Fix Blueprint Dependencies

## Overview
Major simplification of the LDAP Token Retriever Lambda to focus on the critical resource (service account) and actively trigger blueprint re-execution when needed. Also fixes blueprint dependency issues that caused startup failures.

## Key Changes

### 🎯 **Simplified Lambda Logic**
- **Before**: Checked 5 different LDAP resources (service account, flows, providers, applications, outposts)
- **After**: Only checks for LDAP service account (`ldapservice`) - the critical dependency
- **Benefit**: Faster execution, clearer failure modes, reduced complexity

### 🔄 **Active Blueprint Management**
- **New Feature**: Lambda actively triggers blueprint re-execution via REST API
- **API Endpoint**: `POST /api/v3/managed/blueprints/{uuid}/apply/`
- **Logic**: If service account missing → find blueprint → trigger re-execution → wait → repeat
- **Resilience**: Blueprint discovery moved inside retry loop to handle startup timing

### 📋 **Blueprint Dependency Fixes**
- **Issue**: Blueprint failed at startup due to missing default flows
- **Fix**: Changed `required: false` → `required: true` for dependencies
- **Added**: `Default - Authentication flow` dependency
- **Added**: Dependency metadata label: `blueprints.goauthentik.io/depends-on: "default-flows,default-stages"`

## Technical Details

### Lambda Flow (Simplified)
Phase 1: Setup & Authentication
├── Get admin token from Secrets Manager
└── Setup authenticated HTTP client

Phase 2: Ensure Service Account (NEW APPROACH)
├── Check if ldapservice user exists
├── If missing: Find "LDAP Setup for TAK" blueprint
├── Trigger blueprint via POST /managed/blueprints/{uuid}/apply/
├── Wait with exponential backoff (1s → 2s → 4s → 30s cap)
└── Repeat until service account exists or timeout (10min)

Phase 3: Token Retrieval & Storage
├── Get LDAP outpost token from Authentik
└── Store token in AWS Secrets Manager


### Blueprint Improvements
```yaml
# Before
- model: authentik_blueprints.metaapplyblueprint
  attrs:
    identifiers:
      name: Default - Invalidation flow
    required: false  # ❌ Caused startup failures

# After  
- model: authentik_blueprints.metaapplyblueprint
  attrs:
    identifiers:
      name: Default - Invalidation flow
    required: true   # ✅ Ensures dependencies exist
