### PR TITLE
Fix LDAP Blueprint Reliability and Add Database Context Override

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -90,9 +90,20 @@ jobs:
           echo "authentik-tag=$AUTHENTIK_TAG" >> $GITHUB_OUTPUT
           echo "ldap-tag=$LDAP_TAG" >> $GITHUB_OUTPUT
 
+      - name: Configure Database Context
+        id: db-config
+        run: |
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          if [[ "$COMMIT_MSG" != *"[use-prod-db]"* ]]; then
+            echo "🔄 Using dev-test database settings for faster deployment"
+            echo "db-context=--context instanceClass=db.serverless --context instanceCount=1 --context enablePerformanceInsights=false --context monitoringInterval=0 --context backupRetentionDays=7 --context deleteProtection=false --context nodeType=cache.t3.micro --context numCacheNodes=1" >> $GITHUB_OUTPUT
+          else
+            echo "🚀 Using production database settings"
+            echo "db-context=" >> $GITHUB_OUTPUT
+          fi
+
       - name: Deploy Demo with Prod Profile
-        # Use dev-test Redis settings to avoid slow Redis changes (>1 hour deployment)
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context nodeType=cache.t3.micro --context numCacheNodes=1 --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} ${{ steps.db-config.outputs.db-context }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}


### PR DESCRIPTION
# Fix LDAP Blueprint Reliability and Add Database Context Override

## Problem
- LDAP blueprint was failing intermittently on first boot
- Token retriever incorrectly determined service account existed when API returned empty results
- Demo deployments were slow due to production database settings

## Changes
### Blueprint (`tak-ldap-setup.yaml`)
- Added `state: present` to all resources for idempotent operations
- Removed incorrect password stage binding (LDAP doesn't need it)

### Token Retriever (`ldap-token-retriever.ts`)
- Fixed outpost existence check: properly handle `{"results": [], "pagination": {"count": 0}}`
- Always apply blueprint first to ensure LDAP setup is current
- Improved error handling and logging

### Demo Workflow (`demo-deploy.yml`)
- Added database context override matching TakInfra pattern
- Default: uses dev-test DB settings for faster deployments
- Override: use `[use-prod-db]` in commit message for production DB testing

## Result
- More reliable LDAP setup on first boot
- Consistent blueprint application
- Faster demo deployments (~1 hour saved)
- Proper detection of missing outposts/service accounts
