### PR TITLE
Fix: Context Parameter Parsing Issue

### DIFF
--- a/bin/cdk.ts
+++ b/bin/cdk.ts
@@ -14,7 +14,11 @@ const envName = app.node.tryGetContext('envType') || 'dev-test';
 // Get the environment configuration from context
 // CDK automatically handles context overrides via --context flag
 const envConfig = app.node.tryGetContext(envName);
-const defaults = app.node.tryGetContext('tak-defaults');
+const defaults = {
+  project: app.node.tryGetContext('tak-project') || app.node.tryGetContext('tak-defaults')?.project,
+  component: app.node.tryGetContext('tak-component') || app.node.tryGetContext('tak-defaults')?.component,
+  region: app.node.tryGetContext('tak-region') || app.node.tryGetContext('tak-defaults')?.region
+};
 
 if (!envConfig) {
   throw new Error(`

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -341,10 +341,33 @@ npm run deploy:dev -- --context stackName=Demo
 
 ### **Resource Tagging**
 All AWS resources are automatically tagged with:
-- **Project**: "TAK.NZ" (from `tak-defaults.project`)
-- **Component**: "AuthInfra" (from `tak-defaults.component`)
+- **Project**: "TAK.NZ" (from `tak-defaults.project` or `tak-project` override)
+- **Component**: "BaseInfra" (from `tak-defaults.component` or `tak-component` override)
 - **Environment**: The environment name (from `stackName`)
 - **ManagedBy**: "CDK"
+
+### **Project Configuration Overrides**
+The project metadata can be overridden using individual context parameters:
+
+```bash
+# Override project name for custom branding
+npm run deploy:dev -- --context tak-project="Custom TAK Project"
+
+# Override component name (useful for custom deployments)
+npm run deploy:dev -- --context tak-component="CustomBaseInfra"
+
+# Override region for tagging purposes
+npm run deploy:dev -- --context tak-region="us-east-1"
+```
+
+#### **Project Context Parameters**
+| Parameter | Description | Default | Example Override |
+|-----------|-------------|---------|------------------|
+| `tak-project` | Project name for resource tagging | `TAK.NZ` | `"Enterprise TAK"` |
+| `tak-component` | Component name for resource tagging | `BaseInfra` | `"CustomBaseInfra"` |
+| `tak-region` | Region identifier for tagging | `ap-southeast-2` | `"us-west-2"` |
+
+**Note**: These parameters provide backward compatibility with the existing `tak-defaults` object while allowing individual overrides for deployment scripts and CI/CD pipelines.
 
 ---
 


### PR DESCRIPTION
# Fix: Context Parameter Parsing Issue

## Problem
Project name "TAK on AWS" was being truncated to "TAK" in CloudFormation tags due to CDK not parsing JSON strings passed via `--context` flag.

## Solution
- Replace JSON object context parameters with individual parameters
- Use `tak-project`, `tak-component`, `tak-region` instead of `tak-defaults` JSON
- Maintain backward compatibility with existing `tak-defaults` object

## Changes
- **bin/cdk.ts**: Updated context retrieval to use individual parameters with fallback
- **scripts/deploy/deployAllLayers**: Updated all layer deployments to use individual parameters
- **docs/PARAMETERS.md**: Added documentation for new parameter usage
- **docs/CONTEXT_PARAMETER_FIX.md**: Implementation guide for other stacks

## Testing
Project name now correctly appears as "TAK on AWS" in CloudFormation stack tags instead of falling back to "TAK".
