### PR TITLE
Add configurable CloudWatch logs for RDS

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -28,7 +28,8 @@
         "enablePerformanceInsights": false,
         "monitoringInterval": 0,
         "backupRetentionDays": 7,
-        "deleteProtection": false
+        "deleteProtection": false,
+        "enableCloudWatchLogs": false
       },
       "redis": {
         "nodeType": "cache.t3.micro",
@@ -74,7 +75,8 @@
         "enablePerformanceInsights": true,
         "monitoringInterval": 60,
         "backupRetentionDays": 30,
-        "deleteProtection": true
+        "deleteProtection": true,
+        "enableCloudWatchLogs": false
       },
       "redis": {
         "nodeType": "cache.t3.small",

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -166,6 +166,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `monitoringInterval` | Enhanced monitoring interval (seconds) | `0` | `60` |
 | `backupRetentionDays` | Backup retention period (days) | `7` | `30` |
 | `deleteProtection` | Enable deletion protection | `false` | `true` |
+| `enableCloudWatchLogs` | Enable CloudWatch logs for database | `false` | `false` |
 
 ### **Redis Configuration**
 | Parameter | Description | dev-test | prod |
@@ -194,7 +195,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `useS3AuthentikConfigFile` | Use S3 configuration file | `false` | `true` |
 | `enablePostgresReadReplicas` | Enable read replicas (currently disabled) | `false` | `false` |
 | `branding` | Docker image branding variant | `tak-nz` | `tak-nz` |
-| `authentikVersion` | Authentik version | `2025.6.2` | `2025.6.2` |
+| `authentikVersion` | Authentik version | `2025.6.3` | `2025.6.3` |
 | `outboundEmailServerPort` | Email server port for outbound connections | `587` | `587` |
 
 ### **ECR Configuration**
@@ -391,6 +392,7 @@ npm run deploy:dev -- --context tak-region="us-east-1"
 | `monitoringInterval` | number | Enhanced monitoring interval (seconds) | `0`, `15`, `30`, `60` |
 | `backupRetentionDays` | number | Backup retention period (days) | `1-35` |
 | `deleteProtection` | boolean | Enable deletion protection | `true`, `false` |
+| `enableCloudWatchLogs` | boolean | Enable CloudWatch logs for database | `true`, `false` |
 
 ### **Redis Configuration**
 | Parameter | Type | Description | Valid Values |

--- a/lib/constructs/database.ts
+++ b/lib/constructs/database.ts
@@ -168,7 +168,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.contextConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.contextConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.contextConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,
@@ -221,7 +221,7 @@ export class Database extends Construct {
         },
         deletionProtection: props.contextConfig.database.deleteProtection,
         removalPolicy: removalPolicy,
-        cloudwatchLogsExports: ['postgresql'],
+        cloudwatchLogsExports: props.contextConfig.database.enableCloudWatchLogs ? ['postgresql'] : undefined,
         cloudwatchLogsRetention: props.contextConfig.general.enableDetailedLogging ? 
           logs.RetentionDays.ONE_MONTH : 
           logs.RetentionDays.ONE_WEEK,

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -19,6 +19,7 @@ export interface ContextEnvironmentConfig {
     monitoringInterval: number;
     backupRetentionDays: number;
     deleteProtection: boolean;
+    enableCloudWatchLogs?: boolean;
   };
   redis: {
     nodeType: string;

--- a/lib/utils/context-overrides.ts
+++ b/lib/utils/context-overrides.ts
@@ -30,12 +30,14 @@ export function applyContextOverrides(
       ...baseConfig.database,
       instanceClass: app.node.tryGetContext('instanceClass') ?? baseConfig.database.instanceClass,
       instanceCount: Number(app.node.tryGetContext('instanceCount')) || baseConfig.database.instanceCount,
+      engineVersion: app.node.tryGetContext('engineVersion') ?? baseConfig.database.engineVersion,
       allocatedStorage: Number(app.node.tryGetContext('allocatedStorage')) || baseConfig.database.allocatedStorage,
       maxAllocatedStorage: Number(app.node.tryGetContext('maxAllocatedStorage')) || baseConfig.database.maxAllocatedStorage,
       enablePerformanceInsights: contextBoolean(app, 'enablePerformanceInsights', baseConfig.database.enablePerformanceInsights),
       monitoringInterval: Number(app.node.tryGetContext('monitoringInterval')) || baseConfig.database.monitoringInterval,
       backupRetentionDays: Number(app.node.tryGetContext('backupRetentionDays')) || baseConfig.database.backupRetentionDays,
       deleteProtection: contextBoolean(app, 'deleteProtection', baseConfig.database.deleteProtection),
+      enableCloudWatchLogs: contextBoolean(app, 'enableCloudWatchLogs', baseConfig.database.enableCloudWatchLogs),
     },
     redis: {
       ...baseConfig.redis,
@@ -48,6 +50,7 @@ export function applyContextOverrides(
       taskMemory: Number(app.node.tryGetContext('taskMemory')) || baseConfig.ecs.taskMemory,
       desiredCount: Number(app.node.tryGetContext('desiredCount')) || baseConfig.ecs.desiredCount,
       enableDetailedLogging: contextBoolean(app, 'enableDetailedLogging', baseConfig.ecs.enableDetailedLogging),
+      enableEcsExec: contextBoolean(app, 'enableEcsExec', baseConfig.ecs.enableEcsExec),
     },
     authentik: {
       ...baseConfig.authentik,
@@ -60,6 +63,7 @@ export function applyContextOverrides(
       branding: app.node.tryGetContext('branding') ?? baseConfig.authentik.branding,
       authentikVersion: app.node.tryGetContext('authentikVersion') ?? baseConfig.authentik.authentikVersion,
       buildRevision: Number(app.node.tryGetContext('buildRevision')) || baseConfig.authentik.buildRevision,
+      outboundEmailServerPort: Number(app.node.tryGetContext('outboundEmailServerPort')) || baseConfig.authentik.outboundEmailServerPort,
     },
     ecr: {
       imageRetentionCount: Number(app.node.tryGetContext('imageRetentionCount')) || baseConfig.ecr.imageRetentionCount,


### PR DESCRIPTION
## Description
This PR adds the ability to enable or disable CloudWatch logs for RDS database instances via a context parameter. By default, CloudWatch logs are disabled to reduce costs, but they can be enabled when needed for debugging or compliance purposes.

## Changes
- Added `enableCloudWatchLogs` property to database configuration interface
- Set default value to `false` for both dev-test and prod environments
- Added context override support in `context-overrides.ts`
- Updated database construct to conditionally export logs based on the flag
- Updated documentation to include the new parameter

## Testing
- Verified that CloudWatch logs are not created by default
- Tested enabling logs via `--context enableCloudWatchLogs=true`
- Confirmed retention period is correctly applied when logs are enabled

