### PR TITLE
Update GitHub Actions to Use Organization Secrets and Variables

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-DockerBuild
       
       - name: Get ECR Repository and Build Tags
@@ -55,7 +55,7 @@ jobs:
         run: |
           # Get ECR repository ARN from BaseInfra exports
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
-            --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
+            --stack-name TAK-${{ vars.DEMO_STACK_NAME }}-BaseInfra \
             --query 'Stacks[0].Outputs[?OutputKey==`EcrArtifactsRepoArnOutput`].OutputValue' \
             --output text)
           
@@ -66,7 +66,7 @@ jobs:
           
           # Extract repository name from ARN and build URI
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
-          ECR_REPO_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
+          ECR_REPO_URI="${{ secrets.DEMO_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.DEMO_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
           VERSION=$(jq -r '.context."dev-test".authentik.authentikVersion' cdk.json)
           BRANDING=$(jq -r '.context."dev-test".authentik.branding' cdk.json)
@@ -91,7 +91,7 @@ jobs:
       
       - name: Login to Amazon ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.DEMO_AWS_REGION }} | \
             docker login --username AWS --password-stdin \
             ${{ steps.tags.outputs.ecr-repo-uri }}
       

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Validate CDK Synthesis (Prod Profile)
-        run: npm run cdk synth -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }}
+        run: npm run cdk synth -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }}
 
       - name: Validate Change Set
         run: |
@@ -54,7 +54,7 @@ jobs:
           if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-AuthInfra
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.DEMO_STACK_NAME }}-AuthInfra
           fi
 
   # Deploy demo environment with production configuration for testing
@@ -73,8 +73,8 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Extract Image Tags
@@ -103,7 +103,7 @@ jobs:
           fi
 
       - name: Deploy Demo with Prod Profile
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} ${{ steps.db-config.outputs.db-context }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }} --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} ${{ steps.db-config.outputs.db-context }} --require-approval never
 
       - name: Wait for Testing Period
         run: sleep ${{ vars.DEMO_TEST_DURATION || '300' }}
@@ -113,7 +113,7 @@ jobs:
           echo "Placeholder for automated tests"
           # TODO: Add health checks and integration tests
           # Health check URL should be retrieved from BaseInfra stack outputs
-          # curl -f https://$(aws cloudformation describe-stacks --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra --query 'Stacks[0].Outputs[?OutputKey==`DomainNameOutput`].OutputValue' --output text)/health || exit 1
+          # curl -f https://$(aws cloudformation describe-stacks --stack-name TAK-${{ vars.DEMO_STACK_NAME }}-BaseInfra --query 'Stacks[0].Outputs[?OutputKey==`DomainNameOutput`].OutputValue' --output text)/health || exit 1
 
   # Always revert demo environment back to dev-test configuration
   # Ensures demo environment is left in a consistent state regardless of test results
@@ -129,12 +129,12 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.DEMO_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.DEMO_AWS_REGION }}
           role-session-name: GitHubActions-Demo
 
       - name: Validate CDK Synthesis (Dev-Test Profile)
-        run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }}
+        run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }}
 
       - name: Revert Demo to Dev-Test Profile
-        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ needs.deploy-and-test.outputs.authentik-tag }} --context ldapImageTag=${{ needs.deploy-and-test.outputs.ldap-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ needs.deploy-and-test.outputs.authentik-tag }} --context ldapImageTag=${{ needs.deploy-and-test.outputs.ldap-tag }} --require-approval never

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   build-images:
     runs-on: ubuntu-latest
-    environment: prod
+    environment: production
     outputs:
       authentik-tag: ${{ steps.tags.outputs.authentik-tag }}
       ldap-tag: ${{ steps.tags.outputs.ldap-tag }}
@@ -44,8 +44,8 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.PROD_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PROD_AWS_REGION }}
           role-session-name: GitHubActions-DockerBuild
       
       - name: Get ECR Repository and Build Tags
@@ -53,7 +53,7 @@ jobs:
         run: |
           # Get ECR repository ARN from BaseInfra exports
           ECR_REPO_ARN=$(aws cloudformation describe-stacks \
-            --stack-name TAK-${{ vars.STACK_NAME }}-BaseInfra \
+            --stack-name TAK-${{ vars.PROD_STACK_NAME }}-BaseInfra \
             --query 'Stacks[0].Outputs[?OutputKey==`EcrArtifactsRepoArnOutput`].OutputValue' \
             --output text)
           
@@ -64,7 +64,7 @@ jobs:
           
           # Extract repository name from ARN and build URI
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
-          ECR_REPO_URI="${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
+          ECR_REPO_URI="${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.PROD_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
           VERSION=$(jq -r '.context."prod".authentik.authentikVersion' cdk.json)
           BRANDING=$(jq -r '.context."prod".authentik.branding' cdk.json)
@@ -89,7 +89,7 @@ jobs:
       
       - name: Login to Amazon ECR
         run: |
-          aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | \
+          aws ecr get-login-password --region ${{ secrets.PROD_AWS_REGION }} | \
             docker login --username AWS --password-stdin \
             ${{ steps.tags.outputs.ecr-repo-uri }}
       

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
         with:
-          aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.PROD_AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.PROD_AWS_REGION }}
           role-session-name: GitHubActions-Production
 
       - name: Bootstrap CDK (if needed)
         run: |
           if ! aws cloudformation describe-stacks --stack-name CDKToolkit 2>/dev/null; then
-            npx cdk bootstrap aws://${{ secrets.AWS_ACCOUNT_ID }}/${{ secrets.AWS_REGION }} --context envType=prod
+            npx cdk bootstrap aws://${{ secrets.PROD_AWS_ACCOUNT_ID }}/${{ secrets.PROD_AWS_REGION }} --context envType=prod
           fi
 
       - name: Extract Image Tags
@@ -64,8 +64,8 @@ jobs:
           if [[ "$COMMIT_MSG" == *"[force-deploy]"* ]]; then
             echo "🚨 Force deploy detected - skipping change set validation"
           else
-            ./scripts/github/validate-changeset.sh TAK-${{ vars.STACK_NAME }}-AuthInfra
+            ./scripts/github/validate-changeset.sh TAK-${{ vars.PROD_STACK_NAME }}-AuthInfra
           fi
 
       - name: Deploy Production
-        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.STACK_NAME }} --context adminUserEmail=${{ vars.AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=prod --context stackName=${{ vars.PROD_STACK_NAME }} --context adminUserEmail=${{ vars.PROD_AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ steps.images.outputs.authentik-tag }} --context ldapImageTag=${{ steps.images.outputs.ldap-tag }} --require-approval never


### PR DESCRIPTION
## Changes

- Updated all workflow files to use organization secrets and variables instead of environment-specific ones
- Aligned with BaseInfra documentation and configuration approach
- Updated AWS_GITHUB_SETUP.md documentation to reflect these changes

## Testing

- Verified all workflow files reference the correct organization secrets and variables
- Ensured environment names remain as "demo" and "production"

## Related Issues

Aligns with BaseInfra configuration at https://github.com/TAK-NZ/base-infra/blob/main/docs/AWS_GITHUB_SETUP.md
