### PR TITLE
Fix: Prevent OIDC provider/application deletion during deployments

### DIFF
--- a/lib/constructs/enroll-oidc-setup.ts
+++ b/lib/constructs/enroll-oidc-setup.ts
@@ -124,12 +124,19 @@ export class EnrollOidcSetup extends Construct {
     }
 
     // Create custom resource that will invoke the Lambda
-    // Use a unique ID to force recreation
     const customResource = new cdk.CustomResource(this, 'OidcSetupResource', {
       serviceToken: provider.serviceToken,
       properties: {
-        // Add a timestamp to force the custom resource to update on each deployment
-        timestamp: new Date().toISOString(),
+        // Configuration properties that trigger updates when changed
+        providerName: enrollmentConfig.providerName,
+        applicationName: enrollmentConfig.applicationName,
+        applicationSlug: enrollmentConfig.applicationSlug || enrollmentConfig.applicationName.toLowerCase().replace(/[^a-z0-9]/g, '-'),
+        redirectUris: JSON.stringify([redirectUri]),
+        launchUrl: launchUrl,
+        groupName: enrollmentConfig.groupName || '',
+        // Add a timestamp to force updates on every deployment
+        UpdateTimestamp: Date.now().toString()
+
       },
     });
 

--- a/src/enroll-oidc-setup/.env.example
+++ b/src/enroll-oidc-setup/.env.example
@@ -1,0 +1,23 @@
+# Authentik API configuration
+AUTHENTIK_URL=https://account.example.com
+AUTHENTIK_ADMIN_TOKEN=your-admin-api-token-here
+
+# OAuth2 provider configuration
+PROVIDER_NAME=TAK Device Enrollment
+APPLICATION_NAME=TAK Device Enrollment
+APPLICATION_SLUG=tak-device-enrollment
+REDIRECT_URIS=["https://enroll.example.com/oauth2/idpresponse"]
+LAUNCH_URL=https://enroll.example.com/
+OPEN_IN_NEW_TAB=true
+
+# Optional group assignment
+GROUP_NAME=Team Awareness Kit
+
+# Optional application metadata
+APPLICATION_DESCRIPTION=Device enrollment for TAK applications
+ICON_URL=https://example.com/images/TAK-Enroll.png
+
+# Flow configuration (optional - uses defaults if not specified)
+AUTHENTICATION_FLOW_NAME=
+AUTHORIZATION_FLOW_NAME=default-provider-authorization-implicit-consent
+INVALIDATION_FLOW_NAME=default-provider-invalidation-flow

--- a/src/enroll-oidc-setup/README.md
+++ b/src/enroll-oidc-setup/README.md
@@ -17,11 +17,11 @@ The function returns the following OIDC configuration values needed for ALB auth
 
 | Value | Description | Example |
 |-------|-------------|---------|
-| `issuer` | OpenID Configuration Issuer | `https://account.tak.nz` |
+| `issuer` | Application-specific issuer | `https://account.tak.nz/application/o/tak-device-enrollment/` |
 | `authorizeUrl` | Authorization endpoint | `https://account.tak.nz/application/o/authorize/` |
 | `tokenUrl` | Token endpoint | `https://account.tak.nz/application/o/token/` |
 | `userInfoUrl` | User info endpoint | `https://account.tak.nz/application/o/userinfo/` |
-| `jwksUri` | JSON Web Key Set URI | `https://account.tak.nz/application/o/jwks/` |
+| `jwksUri` | JSON Web Key Set URI | `https://account.tak.nz/application/o/tak-device-enrollment/jwks/` |
 | `clientId` | OAuth2 client ID | `abcdef123456` |
 | `clientSecret` | OAuth2 client secret | `********` |
 
@@ -31,22 +31,27 @@ To test the function locally:
 
 1. Create a `.env` file with the required environment variables
 2. Run `node test-local.js` to test the full function
-3. Run `node test-oidc-config.js` to test just the OIDC configuration retrieval
 
 > **Note:** The `.env` file is only used for local testing and is excluded from the Lambda deployment package. Environment variables for the Lambda function are set through the CDK construct.
 
 ## Environment Variables
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `AUTHENTIK_URL` | Authentik base URL | Yes |
-| `AUTHENTIK_ADMIN_TOKEN` | Admin API token | Yes |
-| `PROVIDER_NAME` | OAuth2 provider name | Yes |
-| `APPLICATION_NAME` | Application name | Yes |
-| `APPLICATION_SLUG` | Application slug | No |
-| `REDIRECT_URIS` | JSON array of redirect URIs | Yes |
-| `LAUNCH_URL` | Application launch URL | Yes |
-| `OPEN_IN_NEW_TAB` | Open in new tab (true/false) | No |
-| `AUTHENTICATION_FLOW_NAME` | Authentication flow name | No |
-| `AUTHORIZATION_FLOW_NAME` | Authorization flow name | No |
-| `INVALIDATION_FLOW_NAME` | Invalidation flow name | No |
+| Variable | Description | Required | Default |
+|----------|-------------|----------|----------|
+| `AUTHENTIK_URL` | Authentik base URL | Yes | - |
+| `AUTHENTIK_ADMIN_SECRET_ARN` | Secrets Manager ARN for admin token | Yes* | - |
+| `AUTHENTIK_ADMIN_TOKEN` | Admin API token (local testing only) | Yes* | - |
+| `PROVIDER_NAME` | OAuth2 provider name | Yes | - |
+| `APPLICATION_NAME` | Application name | Yes | - |
+| `APPLICATION_SLUG` | Application slug | No | Auto-generated from name |
+| `REDIRECT_URIS` | JSON array of redirect URIs | Yes | - |
+| `LAUNCH_URL` | Application launch URL | Yes | - |
+| `OPEN_IN_NEW_TAB` | Open in new tab (true/false) | No | `false` |
+| `GROUP_NAME` | Group to assign to application | No | - |
+| `APPLICATION_DESCRIPTION` | Application description | No | - |
+| `ICON_URL` | Application icon URL | No | - |
+| `AUTHENTICATION_FLOW_NAME` | Authentication flow name | No | - |
+| `AUTHORIZATION_FLOW_NAME` | Authorization flow name | No | `default-provider-authorization-implicit-consent` |
+| `INVALIDATION_FLOW_NAME` | Invalidation flow name | No | `default-provider-invalidation-flow` |
+
+*Either `AUTHENTIK_ADMIN_SECRET_ARN` (for Lambda) or `AUTHENTIK_ADMIN_TOKEN` (for local testing) is required.

--- a/src/enroll-oidc-setup/index.js
+++ b/src/enroll-oidc-setup/index.js
@@ -85,8 +85,7 @@ exports.handler = async (event, context) => {
     
     // Handle CloudFormation custom resource events
     if (event.RequestType === 'Delete') {
-      console.log('Handling DELETE request - cleaning up Authentik resources');
-      await handleDelete(api, event.ResourceProperties, event.PhysicalResourceId);
+      console.log('Handling DELETE request - no cleanup needed, preserving Authentik resources');
       return {
         PhysicalResourceId: event.PhysicalResourceId || 'authentik-oidc-setup',
         Status: 'SUCCESS',
@@ -161,7 +160,7 @@ exports.handler = async (event, context) => {
     // Assign group to application if specified
     if (groupName) {
       console.log(`Assigning group '${groupName}' to application`);
-      await assignGroupToApplication(api, application.pk, groupName);
+      await assignGroupToApplication(api, application.slug, groupName);
     }
     
     // Get OIDC configuration endpoints


### PR DESCRIPTION
## Problem
During CDK deployments, the OIDC provider and application were being:
1. Created successfully in Authentik
2. Immediately deleted due to CloudFormation resource replacement behavior
3. Group assignment failing due to incorrect slug usage

This left the enrollment system without proper OIDC configuration.

## Root Causes
1. **Resource replacement**: Changing properties caused CloudFormation to replace the custom resource
2. **Cleanup on delete**: Lambda function was cleaning up Authentik resources when CloudFormation deleted the old resource
3. **Wrong parameter**: Group assignment used `application.pk` instead of `application.slug`

## Solution
1. **Force Lambda execution**: Add timestamp to ensure Lambda runs on every deployment
2. **Preserve resources**: Remove cleanup logic so Authentik resources persist through deployments
3. **Fix group assignment**: Use correct application slug parameter
4. **Improve documentation**: Update README and add .env.example for better developer experience

## Changes
- `lib/constructs/enroll-oidc-setup.ts`: Add timestamp property to force updates
- `src/enroll-oidc-setup/index.js`: Remove cleanup logic and fix group assignment
- `src/enroll-oidc-setup/README.md`: Update with accurate examples and complete variable list
- `src/enroll-oidc-setup/.env.example`: Add template for local testing

## Testing
- [x] OIDC provider and application persist after deployment
- [x] Group assignment works correctly
- [x] Lambda executes on every deployment
- [x] No cleanup occurs during stack updates

Ensures stable OIDC configuration for device enrollment functionality.
