### PR TITLE
Fix CloudFormation Custom Resource Attribute Error

### DIFF
--- a/src/enroll-oidc-setup/index.js
+++ b/src/enroll-oidc-setup/index.js
@@ -232,16 +232,18 @@ exports.handler = async (event, context) => {
         LogicalResourceId: event.LogicalResourceId,
         // Include Data at the top level for CloudFormation
         Data: {
-          ...response.Data,
-          // Ensure these are also at the top level of Data
           clientId: provider.client_id,
           clientSecret: provider.client_secret,
-          issuer: response.Data.issuer
-        },
-        // Also include at the top level for backward compatibility
-        clientId: provider.client_id,
-        clientSecret: provider.client_secret,
-        issuer: response.Data.issuer
+          providerName: providerName,
+          issuer: oidcConfig.issuer,
+          authorizeUrl: oidcConfig.authorizeUrl,
+          tokenUrl: oidcConfig.tokenUrl,
+          token_endpoint: oidcConfig.tokenUrl,
+          userInfoUrl: oidcConfig.userInfoUrl,
+          userinfo_endpoint: oidcConfig.userInfoUrl,
+          jwksUri: oidcConfig.jwksUri,
+          jwks_uri: oidcConfig.jwksUri
+        }
       };
       
       console.log('Returning CloudFormation response:', JSON.stringify(cfnResponse, (key, value) => {


### PR DESCRIPTION
### Problem
CloudFormation was failing with error: "Vendor response doesn't contain clientId attribute" when deploying the OIDC setup custom resource.

### Root Cause
The Lambda function was referencing `response.Data.issuer` when constructing the CloudFormation response, but `response.Data` wasn't fully constructed yet, causing undefined values in the Data object.

### Solution
- Use original values directly (`provider.client_id`, `oidcConfig.issuer`) instead of nested references
- Remove redundant top-level attributes (CloudFormation only uses the `Data` object)
- Ensure all OIDC configuration values are properly included in the `Data` object


