### PR TITLE
Add Configurable Signing Key Support for OAuth2 Providers

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -65,7 +65,8 @@
         "authorizationFlowName": "default-provider-authorization-implicit-consent",
         "invalidationFlowName": "default-provider-invalidation-flow",
         "groupName": "Team Awareness Kit",
-        "description": "Enroll a mobile device with ATAK/iTAK to the TAK server"
+        "description": "Enroll a mobile device with ATAK/iTAK to the TAK server",
+        "signingKeyName": "authentik Self-signed Certificate"
       },
       "ecr": {
         "imageRetentionCount": 5,
@@ -125,7 +126,8 @@
         "authorizationFlowName": "default-provider-authorization-implicit-consent",
         "invalidationFlowName": "default-provider-invalidation-flow",
         "groupName": "Team Awareness Kit",
-        "description": "Enroll an Android device with ATAK to the TAK server"
+        "description": "Enroll an Android device with ATAK to the TAK server",
+        "signingKeyName": "authentik Self-signed Certificate"
       },
       "ecr": {
         "imageRetentionCount": 20,

--- a/lib/constructs/enroll-oidc-setup.ts
+++ b/lib/constructs/enroll-oidc-setup.ts
@@ -82,6 +82,7 @@ export class EnrollOidcSetup extends Construct {
         ...(enrollmentConfig.invalidationFlowName ? { INVALIDATION_FLOW_NAME: enrollmentConfig.invalidationFlowName } : {}),
         ...(enrollmentConfig.groupName ? { GROUP_NAME: enrollmentConfig.groupName } : {}),
         ...(enrollmentConfig.description ? { APPLICATION_DESCRIPTION: enrollmentConfig.description } : {}),
+        ...(enrollmentConfig.signingKeyName ? { SIGNING_KEY_NAME: enrollmentConfig.signingKeyName } : {}),
       },
     });
 

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -58,6 +58,7 @@ export interface ContextEnvironmentConfig {
     groupName?: string;
     description?: string;
     listenerPriority?: number;
+    signingKeyName?: string;
   };
   ecr: {
     imageRetentionCount: number;


### PR DESCRIPTION
### Problem
OAuth2 providers were using Authentik's default signing key (`signing_key: null`) instead of a specific certificate keypair, limiting control over token signing.

### Solution
- Add `signingKeyName` configuration to `cdk.json` (set to "authentik Self-signed Certificate")
- Update TypeScript interfaces to include the new configuration option
- Enhance Lambda function to lookup certificate keypairs by name using `/api/v3/crypto/certificatekeypairs/` API
- Use the retrieved certificate UUID as `signing_key` when creating/updating OAuth2 providers

### Changes
- **Configuration**: Added `signingKeyName` to both dev-test and prod enrollment configs
- **Lambda**: Added `getSigningKeyByName()` helper function with API lookup
- **CDK**: Pass signing key name via `SIGNING_KEY_NAME` environment variable
- **Fallback**: Uses `null` (default) if specified certificate is not found

