### PR TITLE
Add TAK Aware Support to Device Enrollment

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -56,16 +56,16 @@
       },
       "enrollment": {
         "enrollmentEnabled": true,
-        "providerName": "TAK-Device-Enrolment",
-        "applicationName": "TAK Device Enrolment",
-        "applicationSlug": "tak-device-enrolment",
+        "providerName": "TAK-Device-Activation",
+        "applicationName": "TAK Device Enrollment",
+        "applicationSlug": "tak-device-activation",
         "enrollmentHostname": "device",
         "openInNewTab": true,
         "authenticationFlowName": "",
         "authorizationFlowName": "default-provider-authorization-implicit-consent",
         "invalidationFlowName": "default-provider-invalidation-flow",
         "groupName": "Team Awareness Kit",
-        "description": "Enrol a mobile device with ATAK/iTAK to the TAK server",
+        "description": "Enrol a mobile device with ATAK/iTAK/TAK Aware",
         "signingKeyName": "authentik Self-signed Certificate"
       },
       "ecr": {
@@ -117,16 +117,16 @@
       },
       "enrollment": {
         "enrollmentEnabled": true,
-        "providerName": "TAK-Device-Enrolment",
-        "applicationName": "TAK Device Enrolment",
-        "applicationSlug": "tak-device-enrolment",
+        "providerName": "TAK-Device-Activation",
+        "applicationName": "TAK Device Enrollment",
+        "applicationSlug": "tak-device-activation",
         "enrollmentHostname": "device",
         "openInNewTab": true,
         "authenticationFlowName": "",
         "authorizationFlowName": "default-provider-authorization-implicit-consent",
         "invalidationFlowName": "default-provider-invalidation-flow",
         "groupName": "Team Awareness Kit",
-        "description": "Enrol an Android device with ATAK to the TAK server",
+        "description": "Enrol a mobile device with ATAK/iTAK/TAK Aware",
         "signingKeyName": "authentik Self-signed Certificate"
       },
       "ecr": {

--- a/src/enrollment-lambda/index.js
+++ b/src/enrollment-lambda/index.js
@@ -153,12 +153,12 @@ function getCacheControlHeaders() {
 
 function getBrandingStrings(branding) {
   return {
-    heading: branding === 'tak-nz' ? 'TAK.NZ Device Enrolment' : 'Device Enrolment',
+    heading: branding === 'tak-nz' ? 'TAK.NZ Device Enrollment' : 'Device Enrollment',
     footer: branding === 'tak-nz' ? 'TAK.NZ &bull; Team Awareness &bull; Te m&#333;hio o te r&#333;p&#363;' : 'TAK - Team Awareness Kit'
   };
 }
 
-console.log('Loading enrolment function');
+console.log('Loading enrollment function');
 
 /**
  * Main Lambda handler function
@@ -204,7 +204,7 @@ exports.handler = async (event, context) => {
         }
         
         // For data requests, continue with the full processing
-        console.log('Data request - processing enrolment');
+        console.log('Data request - processing enrollment');
         
         // Process the enrollment request
         return await handleEnrollmentRequest(oidcData, event.headers);
@@ -212,7 +212,7 @@ exports.handler = async (event, context) => {
         console.error('Error in handler:', e);
         
         // Prepare error data for the template
-        let errorMessage = 'An error occurred during enrolment';
+        let errorMessage = 'An error occurred during enrollment';
         let errorDetails = 'Please try again later or contact support.';
         let statusCode = 500;
         
@@ -244,7 +244,7 @@ exports.handler = async (event, context) => {
             
             const brandingStrings = getBrandingStrings(branding);
             const errorData = {
-                title: 'Enrolment Error',
+                title: 'Enrollment Error',
                 ...brandingStrings,
                 branding: branding,
                 errorMessage: errorMessage,
@@ -301,7 +301,7 @@ async function handleInitialRequest() {
     
     const brandingStrings = getBrandingStrings(branding);
     const loadingData = {
-        title: 'Loading Enrolment',
+        title: 'Loading Enrollment',
         ...brandingStrings,
         branding: branding
     };
@@ -409,7 +409,7 @@ async function handleEnrollmentRequest(oidcData, headers) {
         identifier: tokenIdentifier,
         intent: 'app_password',
         user: userId,
-        description: 'ATAK enrolment token',
+        description: 'ATAK enrollment token',
         expires: tokenExpirationDate.toISOString(),
         expiring: true
     };
@@ -424,7 +424,7 @@ async function handleEnrollmentRequest(oidcData, headers) {
 
     // Generate QR codes in parallel
     const ATAKqrCodeData = `tak://com.atakmap.app/enroll?host=${takServer}&username=${user}&token=${tokenKey}`;
-    const iTAKqrCodeData = `${takServer},${takServer}8089,ssl`;
+    const iTAKqrCodeData = `${takServer},${takServer},8089,ssl`;
     
     const [ATAKbase64QRCode, iTAKbase64QRCode] = await Promise.all([
         generateBase64QRCode(ATAKqrCodeData),
@@ -434,7 +434,7 @@ async function handleEnrollmentRequest(oidcData, headers) {
     // Prepare template data
     const brandingStrings = getBrandingStrings(branding);
     const data = {
-        title: 'Device Enrolment',
+        title: 'Device Enrollment',
         ...brandingStrings,
         branding: branding,
         server: takServer,
@@ -471,7 +471,7 @@ async function handleEnrollmentRequest(oidcData, headers) {
             body: renderedHTML,
         };
     } catch (error) {
-        console.error('Error rendering enrolment page');
+        console.error('Error rendering enrollment page');
         throw error;
     }
 }
@@ -516,7 +516,7 @@ function generateCountdownScript(expirationTime) {
             if (distance < 0) {
                 clearInterval(x);
                 document.getElementById("timer").innerHTML = "EXPIRED";
-                document.getElementById("enroll_link").innerHTML = "Enrolment link EXPIRED";
+                document.getElementById("enroll_link").innerHTML = "Enrollment link EXPIRED";
             }
         }, 1000);
     `;

--- a/src/enrollment-lambda/views/content.ejs
+++ b/src/enrollment-lambda/views/content.ejs
@@ -6,7 +6,7 @@ const androidIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 51
 </svg>`;
 
 // Define Apple icon SVG
-const appleIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="20" height="24" style="vertical-align: middle; margin-right: 5px;">
+const appleIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="14" height="16" style="vertical-align: middle;">
 <path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/>
 </svg>`;
 
@@ -30,7 +30,7 @@ const safeRole = sanitize(takRole);
 %>
 
 <div class="form-group">
-    <label class="text-info">Enrolment data</label><br>
+    <label class="text-info">Enrollment data</label><br>
     <b>TAK Server:</b> <%= safeServer %></br>
     <b>User:</b> <%= safeUser %></br>
     <b>Callsign:</b> <%= safeCallsign %></br>
@@ -41,51 +41,51 @@ const safeRole = sanitize(takRole);
 </div>
 <hr>
 <div class="form-group">
-    <label class="text-info">Device Enrolment Requirements</label><br>
+    <label class="text-info">Device Enrollment Requirements</label><br>
     <ul>
-        <li><b>Device Registration:</b> This device will be linked to your account. Only enrol devices that you are authorized to use and are personally responsible for.</li>
-        <li><b>Enrolment Duration:</b> Your device enrolment is valid for 1 year. To maintain access, please renew your enrolment before: <i><%= reenroll %></i>.</li>
+        <li><b>Device Registration:</b> This device will be linked to your account. Only enroll devices that you are authorized to use and are personally responsible for.</li>
+        <li><b>Enrollment Duration:</b> Your device enrollment is valid for 1 year. To maintain access, please renew your enrollment before: <i><%= reenroll %></i>.</li>
     </ul>
 </div>
 <hr>
 <div <%= hide_enrollment_link %> class="form-group">
     <label class="text-info">Add This Device</label><br>
-    Already have ATAK installed on this Android device? You can directly enrol this device. 
+    Already have ATAK installed on this Android device? You can directly enroll this device. 
 </div>
 
 <div <%= hide_enrollment_link %> id="enroll_link" class="form-group" align="center">
     <% if (typeof link !== 'undefined' && link) { %>
-        <a id="enroll-button" class="enroll-button" href="<%= link %>" aria-label="Enrol this device now">Enrol now</a>
+        <a id="enroll-button" class="enroll-button" href="<%= link %>" aria-label="Enroll this device now">Enroll now</a>
     <% } else { %>
-        <span class="enroll-button disabled">Enrolment link unavailable</span>
+        <span class="enroll-button disabled">Enrollment link unavailable</span>
     <% } %>
 </div>
 <hr <%= hide_enrollment_link %>>
 
 <div class="form-group">
     <label class="text-info">Add Another Device</label><br>
-    Access this page from a desktop computer to enrol your mobile device.
+    Access this page from a desktop computer to enroll your mobile device.
 
 <div class="tab-container">
     <!-- Tab buttons -->
     <div class="tab-buttons">
-        <button class="tab-button active" onclick="openTab('android-tab')"><%- androidIcon %> <b>Android (ATAK)</b></button>
-        <button class="tab-button" onclick="openTab('iphone-tab')"><%- appleIcon %> <b>iPhone (iTAK)</b></button>
+        <button class="tab-button active" onclick="openTab('android-tab')"><%- androidIcon %> <b>ATAK</b> / <%- appleIcon %> <b>TAK Aware</b></button>
+        <button class="tab-button" onclick="openTab('iphone-tab')"><%- appleIcon %> <b>iTAK</b></button>
     </div>
 
     <!-- Tab content -->
     <div id="android-tab" class="tab-content active">
         <div class="form-group">
             <ul>
-                <li>ATAK must already be installed.</li>
-                <li>Open the camera app on your Android device.</li>
-                <li>Point the camera at the QR code below.</li>
-                <li>Follow the on-screen prompts to complete enrolment.</li>
+                <li>ATAK or TAK Aware must already be installed.</li>
+                <li><b>For ATAK (Android):</b> Open your camera app, point at the QR code below, and tap the link that appears.</li>
+                <li><b>For TAK Aware (iPhone):</b> Open TAK Aware, select <i>"Connect to a TAK Server"</i>, then <i>"Scan Android QR code"</i>, and point the camera at the QR code below.</li>
             </ul>
+
         </div>
         <div class="qr-container">
             <% if (typeof atakQrcode !== 'undefined' && atakQrcode) { %>
-                <img src="<%= atakQrcode %>" alt="QR Code for Android ATAK enrolment" class="qr-code">
+                <img src="<%= atakQrcode %>" alt="QR Code for Android ATAK or TAK Aware enrollment" class="qr-code">
             <% } else { %>
                 <div class="qr-error">QR code generation failed. Please try refreshing the page.</div>
             <% } %>  
@@ -111,7 +111,7 @@ const safeRole = sanitize(takRole);
         </div>
         <div class="qr-container">
             <% if (typeof itakQrcode !== 'undefined' && itakQrcode) { %>
-                <img src="<%= itakQrcode %>" alt="QR Code for iPhone iTAK enrolment" class="qr-code">
+                <img src="<%= itakQrcode %>" alt="QR Code for iPhone iTAK enrollment" class="qr-code">
             <% } else { %>
                 <div class="qr-error">QR code generation failed. Please try refreshing the page.</div>
             <% } %>

--- a/src/enrollment-lambda/views/loader.ejs
+++ b/src/enrollment-lambda/views/loader.ejs
@@ -25,7 +25,7 @@
 
 <div class="loading-container" style="height: auto; margin: 30px 0; text-align: center;">
     <div class="custom-spinner"></div>
-    <p style="font-weight: bold;">Loading enrolment information...</p>
+    <p style="font-weight: bold;">Loading enrollment information...</p>
 </div>
 
 <script>

--- a/src/enrollment-lambda/views/partials/scripts.ejs
+++ b/src/enrollment-lambda/views/partials/scripts.ejs
@@ -56,7 +56,7 @@ function setupTimer(expirationTime) {
             timerElement.className = "timer danger";
             
             if (enrollLinkElement) {
-                enrollLinkElement.innerHTML = "Enrolment link EXPIRED";
+                enrollLinkElement.innerHTML = "Enrollment link EXPIRED";
             }
         }
     }, 1000);

--- a/src/enrollment-lambda/views/partials/store_badges.ejs
+++ b/src/enrollment-lambda/views/partials/store_badges.ejs
@@ -157,14 +157,33 @@ const appleBadge = `<?xml version="1.0" encoding="utf-8"?>
 
 <div class="form-group">
     <label class="text-info">TAK Mobile Apps</label><br>
-    Suggested improvement: "Don't have ATAK or iTAK installed? Download from your device's app store:
+    Don't have ATAK, iTAK or TAK Aware installed? Download from your device's app store:
 </div>
 
-<div class="store-links">
-    <a href='https://play.google.com/store/apps/details?id=com.atakmap.app.civ' target='_blank' rel="noopener" class='store-link store-badge-link'>
-        <%- googleBadge %>
-    </a>
-    <a href='https://apps.apple.com/us/app/itak/id1561656396' target='_blank' rel="noopener" class='store-link store-badge-link'>
-        <%- appleBadge %>
-    </a>
+<div class="app-downloads" style="display: grid; grid-template-columns: 1fr 1fr; row-gap: 20px; max-width: 600px; margin: 0 auto;">
+    <div class="app-item" style="text-align: center;">
+        <div class="app-name"><strong>ATAK</strong></div>
+        <a href='https://play.google.com/store/apps/details?id=com.atakmap.app.civ' target='_blank' rel="noopener" class='store-link store-badge-link'>
+            <%- googleBadge %>
+        </a>
+    </div>
+    
+    <div class="app-item" style="text-align: center;">
+        <div class="app-name"><strong>iTAK</strong></div>
+        <a href='https://apps.apple.com/us/app/itak/id1561656396' target='_blank' rel="noopener" class='store-link store-badge-link'>
+            <%- appleBadge %>
+        </a>
+    </div>
+    
+    <div></div>
+    
+    <div class="app-item" style="text-align: center;">
+        <div class="app-name"><strong>TAK Aware</strong></div>
+        <a href='https://apps.apple.com/in/app/tak-aware/id6738631659' target='_blank' rel="noopener" class='store-link store-badge-link'>
+            <%- appleBadge %>
+        </a>
+    </div>
 </div>
+
+
+


### PR DESCRIPTION
## Summary
Adds support for TAK Aware (iPhone app) to the device enrollment interface, improving clarity for users with different TAK applications.

## Changes
- **Tab reorganization**: Groups ATAK (Android) and TAK Aware (iPhone) together as they use the same QR code workflow, separate from iTAK's manual setup process
- **App downloads**: Expands from 2 to 3 app download links in a grid layout (ATAK, iTAK, TAK Aware)
- **Instructions**: Clarifies different enrollment workflows:
  - ATAK: Camera app → scan QR → tap link
  - TAK Aware: Open app → "Connect to TAK Server" → "Scan Android QR code"
  - iTAK: Manual server configuration
- **UI improvements**: Reduces Apple icon size for better visual consistency

## Testing
- [x] Verified all app store links work correctly
- [x] Confirmed tab switching functionality
- [x] Tested responsive layout on mobile devices

Resolves user confusion between iTAK and TAK Aware enrollment processes.
