### PR TITLE
Fix: Add Missing S3 Config Context to Demo Revert Step

### DIFF
--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -155,4 +155,4 @@ jobs:
         run: npm run cdk synth -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }}
 
       - name: Revert Demo to Dev-Test Profile
-        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }} --context usePreBuiltImages=true --context authentikImageTag=${{ needs.deploy-and-test.outputs.authentik-tag }} --context ldapImageTag=${{ needs.deploy-and-test.outputs.ldap-tag }} --require-approval never
+        run: npm run cdk deploy -- --context envType=dev-test --context stackName=${{ vars.DEMO_STACK_NAME }} --context adminUserEmail=${{ vars.DEMO_AUTHENTIK_ADMIN_EMAIL }} --context useS3AuthentikConfigFile=true --context usePreBuiltImages=true --context authentikImageTag=${{ needs.deploy-and-test.outputs.authentik-tag }} --context ldapImageTag=${{ needs.deploy-and-test.outputs.ldap-tag }} --require-approval never


### PR DESCRIPTION
### Problem
The demo deployment workflow was missing the `useS3AuthentikConfigFile=true` context parameter in the revert-to-dev-test step, causing inconsistency between the initial deployment and revert operations.

### Solution
Added `--context useS3AuthentikConfigFile=true` to the second CDK deploy command in the revert-to-dev-test job.

### Changes
- Updated `.github/workflows/demo-deploy.yml` to include the missing context parameter

### Testing
- [X] Workflow syntax validation passes
- [X] Both deployment steps now use consistent context parameters
