### PR TITLE
Feature: Add Branded Password Reset Email Template

### DIFF
--- a/authentik/temp_fixes/authentik/stages/email/templates/email/password_reset.html
+++ b/authentik/temp_fixes/authentik/stages/email/templates/email/password_reset.html
@@ -1,0 +1,44 @@
+{% extends "email/base.html" %}
+
+{% load i18n %}
+{% load humanize %}
+
+{% block content %}
+<tr>
+  <td align="center">
+    <h1>
+      {% blocktrans with username=user.username %}
+      Hi {{ username }},
+      {% endblocktrans %}
+    </h1>
+  </td>
+</tr>
+<tr>
+  <td align="center">
+    <table border="0">
+      <tr>
+        <td align="center" style="max-width: 300px; padding: 20px 0; color: #212124;">
+          {% blocktrans %}
+          You recently requested to change your password for your TAK.NZ account. Use the button below to set a new password.
+          {% endblocktrans %}
+        </td>
+      </tr>
+      <tr>
+        <td align="center" class="btn btn-primary">
+          <a id="confirm" href="{{ url }}" rel="noopener noreferrer" target="_blank">{% trans 'Reset Password' %}</a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}
+
+{% block sub_content %}
+<tr>
+  <td style="padding: 20px; font-size: 12px; color: #212124;" align="center">
+    {% blocktrans with expires=expires|naturaltime %}
+    If you did not request a password change, please ignore this email. The link above is valid for {{ expires }}.
+    {% endblocktrans %}
+  </td>
+</tr>
+{% endblock %}

--- a/authentik/temp_fixes/authentik/stages/email/templates/email/password_reset.txt
+++ b/authentik/temp_fixes/authentik/stages/email/templates/email/password_reset.txt
@@ -1,0 +1,13 @@
+{% load i18n %}{% load humanize %}{% autoescape off %}{% blocktrans with username=user.username %}Hi {{ username }},{% endblocktrans %}
+
+{% blocktrans %}
+You recently requested to change your password for your TAK.NZ account. Use the link below to set a new password.
+{% endblocktrans %}
+{{ url }}
+{% blocktrans with expires=expires|naturaltime %}
+If you did not request a password change, please ignore this email. The link above is valid for {{ expires }}.
+{% endblocktrans %}
+
+-- 
+Powered by goauthentik.io.
+{% endautoescape %}

--- a/cdk.json
+++ b/cdk.json
@@ -51,7 +51,7 @@
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
         "authentikVersion": "2025.6.4",
-        "buildRevision": 1,
+        "buildRevision": 2,
         "outboundEmailServerPort": 587
       },
       "enrollment": {
@@ -112,7 +112,7 @@
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
         "authentikVersion": "2025.6.4",
-        "buildRevision": 1,
+        "buildRevision": 2,
         "outboundEmailServerPort": 587
       },
       "enrollment": {


### PR DESCRIPTION
### Problem
The default Authentik password reset email template lacks TAK.NZ branding and doesn't provide a consistent user experience with the rest of the authentication system.

### Solution
Added a custom password reset email template with:
- TAK.NZ branding and styling
- Clear instructions for password reset process
- Consistent visual identity with other authentication emails

### Changes
- Added branded password reset email template
- Integrated template into Authentik configuration
- Maintains responsive design for mobile devices
