### PR TITLE
Upgrade Authentik to version 2025.8.1

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -50,8 +50,8 @@
         "useS3AuthentikConfigFile": false,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.8.0",
-        "buildRevision": 0,
+        "authentikVersion": "2025.8.1",
+        "buildRevision": 1,
         "outboundEmailServerPort": 587
       },
       "enrollment": {
@@ -111,8 +111,8 @@
         "useS3AuthentikConfigFile": true,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2025.8.0",
-        "buildRevision": 0,
+        "authentikVersion": "2025.8.1",
+        "buildRevision": 1,
         "outboundEmailServerPort": 587
       },
       "enrollment": {


### PR DESCRIPTION
## Summary
This PR upgrades the Authentik authentication server from version 2025.8.0 to 2025.8.1 across all environments.

## Changes
- Updated `authentikVersion` to `2025.8.1` in both `dev-test` and `prod` configurations
- No breaking configuration changes required
- Maintains existing branding (`tak-nz`) and all current settings

## Testing
- [X] Deploy to dev-test environment and verify functionality
- [X] Test LDAP authentication
- [X] Test device enrollment flow
- [X] Verify OIDC integration
- [X] Deploy to production after dev-test validation

## Deployment Notes
- Standard deployment process applies
- No database migrations or configuration changes required
- Docker images will be rebuilt automatically with new Authentik version

## Related Documentation
- [Authentik Release Notes](https://goauthentik.io/docs/releases/2025.8)
- [Deployment Guide](docs/DEPLOYMENT_GUIDE.md)
