### PR TITLE
fix: resolve sub-package dependency vulnerabilities (#56, #66)

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "follow-redirects": ">=1.16.0"
     },
     "follow-redirects": ">=1.16.0",
-    "brace-expansion": ">=2.0.2",
+    "brace-expansion": ">=2.0.3",
     "picomatch": ">=2.3.2"
   }
 }

--- a/src/enroll-oidc-setup/package-lock.json
+++ b/src/enroll-oidc-setup/package-lock.json
@@ -1349,9 +1349,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/src/enroll-oidc-setup/package.json
+++ b/src/enroll-oidc-setup/package.json
@@ -10,6 +10,10 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.5.7",
-    "brace-expansion": ">=2.0.2"
+    "brace-expansion": ">=2.0.2",
+    "axios": {
+      "follow-redirects": ">=1.16.0"
+    },
+    "follow-redirects": ">=1.16.0"
   }
 }

--- a/src/enroll-oidc-setup/package.json
+++ b/src/enroll-oidc-setup/package.json
@@ -10,7 +10,7 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.5.7",
-    "brace-expansion": ">=2.0.2",
+    "brace-expansion": ">=2.0.3",
     "axios": {
       "follow-redirects": ">=1.16.0"
     },

--- a/src/enrollment-lambda/package-lock.json
+++ b/src/enrollment-lambda/package-lock.json
@@ -1229,10 +1229,13 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bowser": {
       "version": "2.14.1",
@@ -1241,12 +1244,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/camelcase": {

--- a/src/enrollment-lambda/package.json
+++ b/src/enrollment-lambda/package.json
@@ -15,6 +15,6 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.5.7",
-    "brace-expansion": ">=2.0.2"
+    "brace-expansion": ">=2.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Fixes two Dependabot alerts in sub-packages that were not covered by the
root-level npm overrides introduced in #107.

## Changes

### #66 — follow-redirects leaks Custom Authentication Headers (Moderate)

`follow-redirects <=1.15.11` forwards custom authentication headers (e.g.
`X-API-Key`, `X-Auth-Token`) verbatim to cross-domain redirect targets. Only
`authorization`, `proxy-authorization`, and `cookie` are stripped by the
existing regex.

| | Detail |
|---|---|
| Package | `follow-redirects` |
| Affected | `<= 1.15.11` |
| Fixed in | `1.16.0` |
| Location | `src/enroll-oidc-setup/package-lock.json` |
| Introduced via | `axios 1.15.0` → `follow-redirects 1.15.11` |

**Fix:** Added nested `follow-redirects >=1.16.0` override under `axios` in
`src/enroll-oidc-setup/package.json`, matching the pattern already used in the
root `package.json`.

---

### #56 — brace-expansion zero-step sequence causes DoS (Moderate)

A brace pattern with a zero step value (e.g. `{1..2..0}`) causes the sequence
generation loop to run indefinitely, hanging the process for ~3.5 seconds and
allocating ~1.9 GB of memory before throwing a `RangeError`.

| | Detail |
|---|---|
| Package | `brace-expansion` |
| Affected | `>= 2.0.0, < 2.0.3` |
| Fixed in | `2.0.3` |
| Location | `src/enrollment-lambda/package-lock.json` |
| Introduced via | `ejs 3.1.10` → `brace-expansion 2.0.2` |

**Fix:** Bumped the `brace-expansion` override from `>=2.0.2` to `>=2.0.3` in
`src/enrollment-lambda/package.json`, `src/enroll-oidc-setup/package.json`,
and the root `package.json`.

## Testing

All 139 tests pass. Zero vulnerabilities in all three packages.
