### PR TITLE
fix: bump aws-cdk-lib to 2.254.0 to resolve bundled fast-uri vulnerability

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -57,7 +57,7 @@
         "useS3AuthentikConfigFile": false,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2026.2.2",
+        "authentikVersion": "2026.2.3",
         "buildRevision": 1,
         "outboundEmailServerPort": 587
       },
@@ -125,7 +125,7 @@
         "useS3AuthentikConfigFile": true,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2026.2.2",
+        "authentikVersion": "2026.2.3",
         "buildRevision": 1,
         "outboundEmailServerPort": 587
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3830,6 +3830,16 @@
         "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.1.tgz",
+      "integrity": "sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
       "inBundle": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1045.0",
-        "aws-cdk-lib": "^2.253.1",
+        "aws-cdk-lib": "^2.254.0",
         "axios": "^1.16.0",
         "constructs": "^10.6.0",
         "dotenv": "^17.4.2",
@@ -26,7 +26,7 @@
         "@swc/jest": "^0.2.37",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
-        "aws-cdk": "^2.1121.0",
+        "aws-cdk": "^2.1122.0",
         "esbuild": "^0.25.0",
         "jest": "^29.7.0",
         "ts-node": "^10.9.2",
@@ -46,9 +46,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "53.22.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.22.0.tgz",
-      "integrity": "sha512-2GLhjjf7Db697rRyYt6rjN06fwbBIiewPo/jxSCyUN259ejF7NQQRwvrdAQb9Aq2jPaIIp1cfHSoEdXyA6Bb7Q==",
+      "version": "53.24.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.24.0.tgz",
+      "integrity": "sha512-rCwsd0Y9z4CUmV5FhzjbO2MprXjKG0rxCACuLEY40lD+wInvgcHer0lSDo7Xq9Sxe/IoNe/Wxb2YP3GgxvT3GA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -56,7 +56,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.4"
+        "semver": "^7.8.0"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -71,7 +71,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.4",
+      "version": "7.8.0",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3760,9 +3760,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1121.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1121.0.tgz",
-      "integrity": "sha512-cG7CHt/SytYTfwrK+BUNQpqmS1dwhjt8z6ExKL6GK4n+8/6ZCwFzxlZWA/jUd2+Y9xPc+Q8cLKfMqGmgxEXbkg==",
+      "version": "2.1122.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1122.0.tgz",
+      "integrity": "sha512-AI2Ks9qioWLvBPD4IoEtTet3wUG/o/q6U3WR3VCQKH5sNYLLPALo8o9sermNpMnfd1OQkqhL20tp4cEyojrIZg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3773,9 +3773,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.253.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.253.1.tgz",
-      "integrity": "sha512-vy+hA15/ZfSQpivkNdlIn2ZDA2hesp3WJgmtIZJDFwu6xzwv7wH7glbAdu5xCHGcOjepOaTKZSvCPC6sN+0/Vw==",
+      "version": "2.254.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.254.0.tgz",
+      "integrity": "sha512-O7fn6fu1FXb0BgoO/+WeiBXZ16H/q6z4fOndjdG62c9bPU7Z/UeW5gz7qBiwLm4ERvTObobLCqv7wjd8bp+v3A==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "@aws-cdk/cloud-assembly-api",
@@ -3794,8 +3794,8 @@
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.273",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
-        "@aws-cdk/cloud-assembly-api": "^2.2.2",
-        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
+        "@aws-cdk/cloud-assembly-api": "^2.2.3",
+        "@aws-cdk/cloud-assembly-schema": "^53.21.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.3",
@@ -3816,11 +3816,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
-      "version": "2.2.2",
-      "bundleDependencies": [
-        "jsonschema",
-        "semver"
-      ],
+      "version": "2.2.3",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3831,7 +3827,7 @@
         "node": ">= 18.0.0"
       },
       "peerDependencies": {
-        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
+        "@aws-cdk/cloud-assembly-schema": ">=53.21.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -3938,7 +3934,7 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@swc/jest": "^0.2.37",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "^2.1121.0",
+    "aws-cdk": "^2.1122.0",
     "esbuild": "^0.25.0",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1045.0",
-    "aws-cdk-lib": "^2.253.1",
+    "aws-cdk-lib": "^2.254.0",
     "axios": "^1.16.0",
     "constructs": "^10.6.0",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
fast-uri <=3.1.1 is vulnerable to path traversal via percent-encoded dot segments (GHSA-q3j6-qgpj-74h6, closes #91) and fast-uri <=3.1.1 is vulnerable to host confusion via percent-encoded authority delimiters (GHSA-v39h-62p7-jpjc, closes #92). fast-uri is bundled inside aws-cdk-lib and cannot be overridden externally. aws-cdk-lib 2.254.0 bundles fast-uri 3.1.2 which contains both fixes.

Also bumps aws-cdk CLI to ^2.1122.0 to stay in sync, and Authentik to 2026.2.3 in both dev-test and prod.