### PR TITLE
fix: upgrade form-data to 4.0.6 in enroll-oidc-setup (Dependabot #98)

### DIFF
--- a/src/enroll-oidc-setup/package-lock.json
+++ b/src/enroll-oidc-setup/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1045.0",
         "axios": "^1.16.0",
-        "form-data": "^4.0.4"
+        "form-data": "^4.0.6"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1258,16 +1258,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1359,9 +1359,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/src/enroll-oidc-setup/package.json
+++ b/src/enroll-oidc-setup/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1045.0",
     "axios": "^1.16.0",
-    "form-data": "^4.0.4"
+    "form-data": "^4.0.6"
   },
   "overrides": {
     "fast-xml-parser": ">=5.7.0",


### PR DESCRIPTION
Fixes the CRLF injection vulnerability in `src/enroll-oidc-setup`.

**Root cause:** `axios@1.16.0` depends on `form-data@^4.0.0`, which resolves to the vulnerable `4.0.5`. The package also declared `form-data@^4.0.4` as a direct dependency, which had the same problem.

**Fix:**
- Bumped the direct `form-data` dependency from `^4.0.4` → `^4.0.6`
- npm hoists the single `4.0.6` copy, so axios's transitive path also picks it up — no separate override needed

**Resolves:** [[GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx)](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx) — Dependabot alert #98

`npm audit` reports 0 vulnerabilities after this change.