### PR TITLE
Performance improvements

### DIFF
--- a/lib/constructs/database.ts
+++ b/lib/constructs/database.ts
@@ -147,7 +147,7 @@ export class Database extends Construct {
         credentials: rds.Credentials.fromSecret(this.masterSecret),
         defaultDatabaseName: DATABASE_CONSTANTS.DEFAULT_DATABASE_NAME,
         port: DATABASE_CONSTANTS.PORT,
-        serverlessV2MinCapacity: 0.5,
+        serverlessV2MinCapacity: 2,
         serverlessV2MaxCapacity: 4,
         writer: rds.ClusterInstance.serverlessV2('writer'),
         readers: dbConfig.instanceCount > 1 ? 


### PR DESCRIPTION
Raise Aurora Serverless v2 min capacity from 0.5 to 2 ACU Prevents scale-from-near-zero delays on the Authentik database, which were contributing to slow cold-start login times.