### PR TITLE
chore: upgrade Authentik to 2026.5.4

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -57,7 +57,7 @@
         "useS3AuthentikConfigFile": false,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2026.5.3",
+        "authentikVersion": "2026.5.4",
         "buildRevision": 1,
         "outboundEmailServerPort": 587
       },
@@ -125,7 +125,7 @@
         "useS3AuthentikConfigFile": true,
         "enablePostgresReadReplicas": false,
         "branding": "tak-nz",
-        "authentikVersion": "2026.5.3",
+        "authentikVersion": "2026.5.4",
         "buildRevision": 1,
         "outboundEmailServerPort": 587
       },


### PR DESCRIPTION
Bumps the Authentik version from `2026.5.3` to `2026.5.4` in `cdk.json` for both the demo and production environment configurations.