### PR TITLE
fix: bump brace-expansion to patched version in enrollment-lambda

### DIFF
--- a/src/enrollment-lambda/package-lock.json
+++ b/src/enrollment-lambda/package-lock.json
@@ -1131,15 +1131,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/camelcase": {

--- a/src/enrollment-lambda/package.json
+++ b/src/enrollment-lambda/package.json
@@ -15,6 +15,6 @@
   },
   "overrides": {
     "fast-xml-parser": ">=5.7.0",
-    "brace-expansion": ">=5.0.6"
+    "brace-expansion": ">=5.0.8"
   }
 }


### PR DESCRIPTION
## Summary
Resolves Dependabot alert #114: brace-expansion DoS via exponential-time expansion of consecutive non-expanding `{}` groups ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)).

## Change
- `src/enrollment-lambda/package.json`: raised the `brace-expansion` override floor from `>=5.0.6` to `>=5.0.8` (patched in 5.0.7+)
- `src/enrollment-lambda/package-lock.json`: regenerated, now resolves `brace-expansion` to `5.0.9`

Transitive path: `ejs → jake → filelist → minimatch → brace-expansion`

## Testing
- `npm install` in `src/enrollment-lambda`: 0 vulnerabilities reported
- `npx jest test/unit/constructs/enrollment-lambda.test.ts`: 9/9 tests pass