### PR TITLE
Aurora sizing fixes, connection tuning, and CDK update

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,7 @@
 # GHSA-rgw5-rvv9-x895: brace-expansion DoS bundled inside aws-cdk-lib's
 # minimatch dependency cannot be fixed via package.json overrides, since npm
 # overrides do not apply to bundled dependencies. Ignored until aws-cdk-lib
-# ships a release bundling brace-expansion >=5.0.9 (current: aws-cdk-lib
-# 2.263.0 bundles brace-expansion 5.0.8). Re-check on every aws-cdk-lib upgrade.
+# ships a release bundling brace-expansion >=5.0.9 (still affected as of
+# aws-cdk-lib 2.264.0, which bundles brace-expansion 5.0.8). Re-check on
+# every aws-cdk-lib upgrade.
 audit-level=critical

--- a/authentik/blueprints/tak-ldap-setup.yaml
+++ b/authentik/blueprints/tak-ldap-setup.yaml
@@ -77,7 +77,7 @@ entries:
       geoip_binding: bind_continent
       network_binding: bind_asn
       remember_me_offset: seconds=0
-      session_duration: seconds=0
+      session_duration: hours=1
     identifiers:
         name: ldap-authentication-login
     model: authentik_stages_user_login.userloginstage
@@ -115,7 +115,7 @@ entries:
     attrs:
       authorization_flow: !KeyOf ldap-authentication-flow
       base_dn: !Context basedn
-      bind_mode: direct
+      bind_mode: cached
       gid_start_number: 4000
       invalidation_flow: !Find [authentik_flows.flow, [slug, default-invalidation-flow]]
       mfa_support: true

--- a/cdk.json
+++ b/cdk.json
@@ -34,8 +34,8 @@
 
       "ecs": {
         "server": {
-          "taskCpu": 2048,
-          "taskMemory": 4096
+          "taskCpu": 1024,
+          "taskMemory": 2048
         },
         "worker": {
           "taskCpu": 1024,
@@ -88,7 +88,7 @@
     "prod": {
       "stackName": "Prod",
       "database": {
-        "instanceClass": "db.t4g.large",
+        "instanceClass": "db.r7g.large",
         "instanceCount": 2,
         "engineVersion": "17.4",
         "allocatedStorage": 100,
@@ -106,8 +106,8 @@
           "taskMemory": 4096
         },
         "worker": {
-          "taskCpu": 1024,
-          "taskMemory": 2048
+          "taskCpu": 2048,
+          "taskMemory": 4096
         },
         "ldap": {
           "taskCpu": 512,

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -193,7 +193,7 @@ Use CDK's built-in `--context` flag with **flat parameter names** to override an
 | `ldapHostname` | Hostname for LDAP service | `ldap` | `ldap` |
 | `ldapBaseDn` | LDAP base DN | `dc=tak,dc=nz` | `dc=tak,dc=nz` |
 | `useS3AuthentikConfigFile` | Use S3 configuration file | `false` | `true` |
-| `enablePostgresReadReplicas` | Enable read replicas (currently disabled) | `false` | `false` |
+| `enablePostgresReadReplicas` | Enable read replicas (currently disabled - read replica support is broken in Authentik, see [goauthentik/authentik#15191](https://github.com/goauthentik/authentik/issues/15191); only enable after the manual workaround from that issue has been applied) | `false` | `false` |
 | `branding` | Docker image branding variant | `tak-nz` | `tak-nz` |
 | `authentikVersion` | Authentik version | `2025.6.3` | `2025.6.3` |
 | `outboundEmailServerPort` | Email server port for outbound connections | `587` | `587` |

--- a/lib/constructs/authentik-server.ts
+++ b/lib/constructs/authentik-server.ts
@@ -275,6 +275,10 @@ export class AuthentikServer extends Construct {
       environment: {
         AUTHENTIK_POSTGRESQL__HOST: props.application.database.hostname,
         AUTHENTIK_POSTGRESQL__SSLMODE: 'require',
+        // Enable persistent DB connections to avoid a full connect/TLS handshake per request.
+        // See https://docs.goauthentik.io/install-config/configuration/#connection-management
+        AUTHENTIK_POSTGRESQL__CONN_MAX_AGE: '300',
+        AUTHENTIK_POSTGRESQL__CONN_HEALTH_CHECKS: 'true',
         ...(props.application.database.readReplicaHostname && {
           AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__HOST: props.application.database.readReplicaHostname,
           AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__NAME: 'authentik',

--- a/lib/constructs/authentik-worker.ts
+++ b/lib/constructs/authentik-worker.ts
@@ -273,6 +273,10 @@ export class AuthentikWorker extends Construct {
       environment: {
         AUTHENTIK_POSTGRESQL__HOST: props.application.database.hostname,
         AUTHENTIK_POSTGRESQL__SSLMODE: 'require',
+        // Enable persistent DB connections to avoid a full connect/TLS handshake per request.
+        // See https://docs.goauthentik.io/install-config/configuration/#connection-management
+        AUTHENTIK_POSTGRESQL__CONN_MAX_AGE: '300',
+        AUTHENTIK_POSTGRESQL__CONN_HEALTH_CHECKS: 'true',
         ...(props.application.database.readReplicaHostname && {
           AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__HOST: props.application.database.readReplicaHostname,
           AUTHENTIK_POSTGRESQL__READ_REPLICAS__0__NAME: 'authentik',

--- a/lib/constructs/database.ts
+++ b/lib/constructs/database.ts
@@ -177,11 +177,10 @@ export class Database extends Construct {
       });
     } else {
       // Provisioned instances configuration
-      const instanceType = ec2.InstanceType.of(
-        ec2.InstanceClass.T4G,
-        dbConfig.instanceClass.includes('large') ? ec2.InstanceSize.LARGE :
-        ec2.InstanceSize.MEDIUM
-      );
+      // Parse the instance class directly from context (e.g. "db.r7g.large" -> "r7g.large")
+      // rather than hardcoding a single instance family/size combination, so any
+      // provisioned class configured in cdk.json (t4g, r6g, r7g, etc.) is honored correctly.
+      const instanceType = new ec2.InstanceType(dbConfig.instanceClass.replace(/^db\./, ''));
 
       this.cluster = new rds.DatabaseCluster(this, 'DBCluster', {
         engine: rds.DatabaseClusterEngine.auroraPostgres({

--- a/lib/stack-config.ts
+++ b/lib/stack-config.ts
@@ -45,6 +45,12 @@ export interface ContextEnvironmentConfig {
     ldapHostname: string;
     ldapBaseDn?: string;
     useS3AuthentikConfigFile?: boolean;
+    /**
+     * Enable routing Authentik read queries to the Aurora reader instance/endpoint.
+     * Defaults to false: read replica support is currently broken in Authentik and
+     * requires manual intervention to work correctly.
+     * See https://github.com/goauthentik/authentik/issues/15191
+     */
     enablePostgresReadReplicas?: boolean;
     branding: string;
     authentikVersion: string;

--- a/lib/utils/config-validator.ts
+++ b/lib/utils/config-validator.ts
@@ -23,8 +23,12 @@ export class ConfigValidator {
   }
 
   private static validateDatabase(dbConfig: any): void {
-    const validInstanceClasses = ['db.serverless', 'db.t3.micro', 'db.t3.small', 'db.t4g.micro', 'db.t4g.small', 'db.t4g.medium', 'db.t4g.large'];
-    if (!validInstanceClasses.includes(dbConfig.instanceClass)) {
+    // Matches "db.serverless" or any standard RDS/Aurora instance class naming
+    // pattern, e.g. db.t4g.large, db.r6g.xlarge, db.r7g.2xlarge, db.r8gd.large.
+    // A fixed allow-list would need code changes every time a new instance
+    // family/generation is adopted, so we validate the shape instead.
+    const instanceClassPattern = /^db\.(serverless|[a-z]+\d[a-z]*\.(nano|micro|small|medium|large|\d{1,2}xlarge))$/;
+    if (!instanceClassPattern.test(dbConfig.instanceClass)) {
       throw new Error(`Invalid database instance class: ${dbConfig.instanceClass}`);
     }
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1045.0",
-        "aws-cdk-lib": "^2.263.0",
+        "aws-cdk-lib": "^2.264.0",
         "axios": "^1.18.0",
         "constructs": "^10.8.1",
         "dotenv": "^17.4.2",
@@ -3785,9 +3785,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.263.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
-      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
+      "version": "2.264.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.264.0.tgz",
+      "integrity": "sha512-TzeWc4aM2qftdoWzIgqV7DotzUO9+DqYLXHvL2qygZqkrJdvITTp8ojHstxYPH40FfA+RL4x5hVfa52NCTB0ZA==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1045.0",
-    "aws-cdk-lib": "^2.263.0",
+    "aws-cdk-lib": "^2.264.0",
     "axios": "^1.18.0",
     "constructs": "^10.8.1",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary
- Fixed two hardcoded-value bugs in the Database construct found while updating the prod Aurora instance class: `database.ts` always built the instance type from `ec2.InstanceClass.T4G` regardless of `dbConfig.instanceClass`, and `config-validator.ts` had a stale allow-list that only recognized t3/t4g classes. Both now derive from/validate the configured class generically, so future instance-class changes won't need code edits.
- Updated prod DB `instanceClass` from `db.t4g.large` to `db.r7g.large` to remove CPU-credit exhaustion risk under sustained load (t4g is burstable, r7g is not). Confirmed available in SYD, PDX, and AKL at comparable cost (~$0.33-0.35/hr vs ~$0.23/hr for t4g.large in SYD).
- Resized prod worker task (1024/2048 → 2048/4096) for extra headroom while a suspected worker memory leak is investigated separately (see below). Resized dev-test server task (2048/4096 → 1024/2048) based on 14-day CloudWatch usage that stayed well under the smaller allocation outside of a one-off DB-scaling incident window.
- Added `AUTHENTIK_POSTGRESQL__CONN_MAX_AGE=300` and `CONN_HEALTH_CHECKS=true` to the server and worker containers, enabling persistent DB connections instead of a fresh connect+TLS handshake per request.
- Documented why `enablePostgresReadReplicas` defaults to `false` (Authentik read-replica support is currently broken upstream: [goauthentik/authentik#15191](https://github.com/goauthentik/authentik/issues/15191)) in `PARAMETERS.md` and the config type definition. The gating logic itself already had this note.
- Updated `aws-cdk-lib` to `2.264.0`. `aws-cdk` (CLI) and `constructs` were already at latest. Re-verified the `brace-expansion` audit suppression in `.npmrc` per its existing note to re-check on every `aws-cdk-lib` upgrade — still unresolved upstream, suppression still needed.
- Manual edit to `authentik/blueprints/tak-ldap-setup.yaml`: `session_duration` (`seconds=0` → `hours=1`) and `bind_mode` (`direct` → `cached`).

## Testing
- `tsc --noEmit` clean
- Full test suite: 139/139 passing
- `cdk synth` succeeds for both `dev-test` and `prod` contexts; confirmed in the synthesized templates that `DBInstanceClass` renders as `db.r7g.large` for both writer/reader in prod, `CONN_MAX_AGE` is present on both server/worker task defs, and ECS task CPU/memory match the updated `cdk.json` values
- Not deployed to any environment yet — all changes so far verified via synth/unit tests only

## Known follow-ups (not in this PR)
- Suspected memory leak in the Authentik worker task (steady, unbounded growth observed in demo, ~0.87%/hr with no plateau). Increasing worker memory in prod buys time but doesn't fix the underlying issue.
- Connection pooling (PgBouncer for the server tier only — RDS Proxy is a poor fit here since Authentik's worker relies on `LISTEN`/session-level advisory locks, both of which force RDS Proxy to pin connections and defeat pooling).
- LDAP outpost task looks over-provisioned relative to actual usage (max 33% CPU, 8.4% memory) — candidate for a future size reduction, not urgent.