### PR TITLE
chore: update CDK and GitHub Actions to latest versions

### DIFF
--- a/.github/actions/setup-cdk/action.yml
+++ b/.github/actions/setup-cdk/action.yml
@@ -17,13 +17,13 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
         cache: 'npm'
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.aws-role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/cdk-test.yml
+++ b/.github/workflows/cdk-test.yml
@@ -29,13 +29,13 @@ jobs:
       - run: echo "👾 Repository is ${{ github.repository }}."
       
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
             node-version: '22'
             registry-url: https://registry.npmjs.org/

--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -41,7 +41,7 @@ jobs:
       ldap-tag: ${{ steps.tags.outputs.ldap-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/demo-deploy.yml
+++ b/.github/workflows/demo-deploy.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [test]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -75,7 +75,7 @@ jobs:
       ldap-tag: ${{ steps.images.outputs.ldap-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk
@@ -138,7 +138,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -39,7 +39,7 @@ jobs:
       ldap-tag: ${{ steps.tags.outputs.ldap-tag }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [test, build-images]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Setup CDK Environment
         uses: ./.github/actions/setup-cdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Fetch full history for changelog generation
 
@@ -62,7 +62,7 @@ jobs:
           echo "🚀 **Deployment:** This release will trigger production deployment after approval." >> RELEASE_NOTES.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: RELEASE_NOTES.md
           generate_release_notes: true  # GitHub will append auto-generated notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.1045.0",
-        "aws-cdk-lib": "^2.264.0",
+        "aws-cdk-lib": "^2.265.0",
         "axios": "^1.18.0",
         "constructs": "^10.8.1",
         "dotenv": "^17.4.2",
@@ -26,7 +26,7 @@
         "@swc/jest": "^0.2.37",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
-        "aws-cdk": "^2.1135.1",
+        "aws-cdk": "^2.1136.0",
         "esbuild": "^0.28.1",
         "jest": "^29.7.0",
         "ts-node": "^10.9.2",
@@ -34,9 +34,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.282",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.282.tgz",
-      "integrity": "sha512-7hKMi5tTxDcKGIMIOq14PnY0GBcugW33Uh/2YHDZiEwSxLeFOCYBwhR+BFXONb/EJeVI3RETFgailNZbkcKF6g==",
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -3772,9 +3772,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.1135.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1135.1.tgz",
-      "integrity": "sha512-g1jcMfWlyYtGamFJ/kPBOCuchl3NfwTF2UwOLTIDN0nJbGm84EAO+c8DlYnaemM8UmKFkdoq4BGdmiNL5nHWwA==",
+      "version": "2.1136.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1136.0.tgz",
+      "integrity": "sha512-n6kCL9R9uuvb7WXEwiSs3rYGwnTy9AHHmxOT5Pj5/++E4PYz2bLDXIxzoiOMIj5maoyC52PTe/0GezFV+O0ILQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3785,9 +3785,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.264.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.264.0.tgz",
-      "integrity": "sha512-TzeWc4aM2qftdoWzIgqV7DotzUO9+DqYLXHvL2qygZqkrJdvITTp8ojHstxYPH40FfA+RL4x5hVfa52NCTB0ZA==",
+      "version": "2.265.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz",
+      "integrity": "sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -3804,11 +3804,11 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.282",
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.6.0-beta",
+        "@aws/cloudformation-validate": "1.7.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -3843,7 +3843,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.6.0-beta",
+      "version": "1.7.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3864,7 +3864,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
+      "version": "5.0.9",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@swc/jest": "^0.2.37",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "^2.1135.1",
+    "aws-cdk": "^2.1136.0",
     "esbuild": "^0.28.1",
     "jest": "^29.7.0",
     "ts-node": "^10.9.2",
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.1045.0",
-    "aws-cdk-lib": "^2.264.0",
+    "aws-cdk-lib": "^2.265.0",
     "axios": "^1.18.0",
     "constructs": "^10.8.1",
     "dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary
- Bump `aws-cdk` (2.1135.1 → 2.1136.0) and `aws-cdk-lib` (2.264.0 → 2.265.0)
- Update GitHub Actions to their latest Node.js 24-based releases:
  - `actions/checkout` v4 → v7
  - `actions/setup-node` v4 → v7
  - `aws-actions/configure-aws-credentials` v4 → v6
  - `softprops/action-gh-release` v2 → v3

## Why
GitHub Actions runners are deprecating Node.js 20 and forcing actions onto
Node.js 24. Several of our workflows were pinned to action versions that
still target Node 20, producing deprecation warnings on every run (build-images,
build-test, validate-prod, deploy-and-test, revert-to-dev-test). Updating to
the latest major versions resolves these warnings.

## Testing
- `npm run build` passes (tsc compiles cleanly)
- `npm test` passes: 24 suites / 139 tests, all green
- Verified each Action's latest release via GitHub API before pinning

## Notes
- No CDK app code changes were required for this bump.
- Workflow behavior/inputs are unchanged; only action versions were updated.
